### PR TITLE
[kestros-sample-sites] Add missing pom.xml descriptions

### DIFF
--- a/basic-components-sample/pom.xml
+++ b/basic-components-sample/pom.xml
@@ -16,6 +16,7 @@
     <version>0.0.3</version>
 
     <name>Basic Components Sample Site</name>
+    <description>Sample site demonstrating Kestros basic components</description>
 
     <packaging>bundle</packaging>
 

--- a/explore/app/pom.xml
+++ b/explore/app/pom.xml
@@ -33,6 +33,7 @@
   <version>0.0.1-SNAPSHOT</version>
 
   <name>Explore Site - Application</name>
+  <description>Application bundle for the Explore sample site</description>
   <packaging>bundle</packaging>
 
   <properties>

--- a/explore/content/pom.xml
+++ b/explore/content/pom.xml
@@ -33,6 +33,7 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <name>Explore Site - Content</name>
+    <description>Content bundle for the Explore sample site</description>
     <packaging>bundle</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <version>0.1.1-SNAPSHOT</version>
 
   <name>Kestros Sample Sites</name>
-  <description></description>
+  <description>Sample sites and demo applications for the Kestros CMS platform</description>
   <packaging>pom</packaging>
 
   <licenses>


### PR DESCRIPTION
## Summary
Added or filled in `<description>` elements for all 4 active pom.xml files that were missing them, following Maven conventions.

## Changes
- `pom.xml` (root): filled in the existing empty `<description>` with "Sample sites and demo applications for the Kestros CMS platform"
- `explore/app/pom.xml`: added `<description>Application bundle for the Explore sample site</description>` after `<name>`
- `explore/content/pom.xml`: added `<description>Content bundle for the Explore sample site</description>` after `<name>`
- `basic-components-sample/pom.xml`: added `<description>Sample site demonstrating Kestros basic components</description>` after `<name>`

No other elements were modified. `explore/pom.xml` was left unchanged (already has a valid description). Each file's existing indentation style was preserved.

## Test Instructions
1. `mvn validate -N` on the root pom -- verifies no XML syntax breakage
2. `mvn validate` (recursive) -- verifies all child pom files parse correctly
3. Both passed at commit time with BUILD SUCCESS