### PR TITLE
feat: add signal-conf module with custom datasources (TASK-223)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <module>explore</module>
 <!--    <module>resolve-2021</module>-->
     <module>basic-components-sample</module>
+    <module>signal-conf</module>
   </modules>
 
   <dependencyManagement>

--- a/signal-conf/pom.xml
+++ b/signal-conf/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kestros.cms</groupId>
+        <artifactId>kestros-site-parent</artifactId>
+        <version>0.1.2</version>
+    </parent>
+
+    <groupId>io.kestros.samples</groupId>
+    <artifactId>signal-conf</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <name>Signal Conf Sample Site</name>
+    <description>Signal conference sample site demonstrating custom datasources</description>
+
+    <packaging>bundle</packaging>
+
+    <properties>
+        <rootPackage>io.kestros.samples.signalconf</rootPackage>
+        <bundleCategory>kestros</bundleCategory>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-basic-components</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-site-building-api</artifactId>
+            <version>0.1.4-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-component-types-api</artifactId>
+            <version>0.1.3-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-tagging-api</artifactId>
+            <version>[0.1.3,0.1.99]</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/content/jcr_root</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <version>1.3.6</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                            <goal>package</goal>
+                            <goal>analyze-classes</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packageType>mixed</packageType>
+                    <failOnMissingEmbed>true</failOnMissingEmbed>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <allowIndexDefinitions>true</allowIndexDefinitions>
+                    <filterSource>${basedir}/src/content/META-INF/vault/filter.xml</filterSource>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Sling-Initial-Content>
+                            /libs/kestros/samples/signal-conf;overwrite:=true;path:=/libs/kestros/samples/signal-conf,
+                            /content/sites;overwrite:=true;path:=/content/sites
+                        </Sling-Initial-Content>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>installPackage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.wcm.maven.plugins</groupId>
+                        <artifactId>wcmio-content-package-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <serviceURL>
+                                ${sling.protocol}://${sling.host}:${sling.port}/bin/cpm/package.service.html
+                            </serviceURL>
+                            <userId>${sling.username}</userId>
+                            <password>${sling.password}</password>
+                            <packageFile>target/${project.artifactId}-${project.version}.zip
+                            </packageFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>installBundle</id>
+        </profile>
+    </profiles>
+
+</project>

--- a/signal-conf/pom.xml
+++ b/signal-conf/pom.xml
@@ -89,9 +89,9 @@
                 <configuration>
                     <instructions>
                         <Sling-Initial-Content>
-                            /libs/kestros/samples/signal-conf;overwrite:=true;path:=/libs/kestros/samples/signal-conf,
-                            /content/sites;overwrite:=true;path:=/content/sites
+                            /libs/kestros/samples/signal-conf;overwrite:=true;path:=/libs/kestros/samples/signal-conf
                         </Sling-Initial-Content>
+                        <Sling-Model-Packages>io.kestros.samples.signalconf</Sling-Model-Packages>
                     </instructions>
                 </configuration>
             </plugin>

--- a/signal-conf/src/content/META-INF/vault/config.xml
+++ b/signal-conf/src/content/META-INF/vault/config.xml
@@ -1,0 +1,37 @@
+<vaultfs version="1.1">
+    <aggregates>
+        <aggregate type="file" title="File Aggregate"/>
+        <aggregate type="filefolder" title="File/Folder Aggregate"/>
+        <aggregate type="nodetype" title="Node Type Aggregate" />
+        <aggregate type="full" title="Full Coverage Aggregate">
+            <matches>
+                <include nodeType="rep:AccessControl" respectSupertype="true" />
+                <include nodeType="rep:Policy" respectSupertype="true" />
+                <include nodeType="vlt:FullCoverage" respectSupertype="true" />
+                <include nodeType="mix:language" respectSupertype="true" />
+                <include nodeType="sling:OsgiConfig" respectSupertype="true" />
+            </matches>
+        </aggregate>
+        <aggregate type="generic" title="Folder Aggregate">
+            <matches>
+                <include nodeType="nt:folder" respectSupertype="true" />
+            </matches>
+            <contains>
+                <exclude isNode="true" />
+            </contains>
+        </aggregate>
+        <aggregate type="generic" title="Default Aggregator" isDefault="true">
+            <matches>
+            </matches>
+            <contains>
+                <exclude nodeType="nt:hierarchyNode" respectSupertype="true" />
+            </contains>
+        </aggregate>
+    </aggregates>
+    <handlers>
+        <handler type="folder"/>
+        <handler type="file"/>
+        <handler type="nodetype"/>
+        <handler type="generic"/>
+    </handlers>
+</vaultfs>

--- a/signal-conf/src/content/META-INF/vault/filter.xml
+++ b/signal-conf/src/content/META-INF/vault/filter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workspaceFilter version="1.0">
+
+  <filter root="/content/sites/signal-conf"/>
+
+</workspaceFilter>

--- a/signal-conf/src/content/META-INF/vault/settings.xml
+++ b/signal-conf/src/content/META-INF/vault/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vault version="1.0">
+  <ignore name=".svn"/>
+  <ignore name=".git"/>
+</vault>

--- a/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
+++ b/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io"
+          xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="kes:Site"
+          jcr:title="Signal Conf"
+          jcr:description="Signal Conference sample site demonstrating custom datasources">
+    <jcr:content
+            jcr:primaryType="nt:unstructured"
+            jcr:title="Signal Conf"
+            jcr:description="Signal Conference sample site"/>
+    <presenters
+            jcr:primaryType="kes:Page"
+            jcr:title="Presenters">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Presenters"
+                jcr:description="Conference presenters">
+            <card-list
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                    kes:datasource="presenters"
+                    pagesPath="/content/sites/signal-conf/presenters"
+                    readMoreText="View Sessions"/>
+        </jcr:content>
+        <alice-smith
+                jcr:primaryType="kes:Page"
+                jcr:title="Alice Smith">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Alice Smith"
+                    jcr:description="Senior Developer">
+                <button-group
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                        kes:datasource="presenter-sessions"
+                        sessionsPath="/content/sites/signal-conf/sessions"/>
+            </jcr:content>
+        </alice-smith>
+        <bob-jones
+                jcr:primaryType="kes:Page"
+                jcr:title="Bob Jones">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Bob Jones"
+                    jcr:description="Lead Architect">
+                <button-group
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                        kes:datasource="presenter-sessions"
+                        sessionsPath="/content/sites/signal-conf/sessions"/>
+            </jcr:content>
+        </bob-jones>
+    </presenters>
+    <sessions
+            jcr:primaryType="kes:Page"
+            jcr:title="Sessions">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Sessions"
+                jcr:description="Conference sessions"/>
+        <intro-to-sling
+                jcr:primaryType="kes:Page"
+                jcr:title="Introduction to Sling">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Introduction to Sling"
+                    jcr:description="Learn the basics of Apache Sling"
+                    sessionTime="9:00 AM"
+                    presenterName="Alice Smith"
+                    presenterPath="/content/sites/signal-conf/presenters/alice-smith"
+                    kes:tags="[/etc/tags/signal-conf/day-1,/etc/tags/signal-conf/topic/sling]">
+                <related-sessions
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                        kes:datasource="tag-search"
+                        pagesPath="/content/sites/signal-conf/sessions"
+                        readMoreText="View Session"/>
+            </jcr:content>
+        </intro-to-sling>
+        <advanced-htl
+                jcr:primaryType="kes:Page"
+                jcr:title="Advanced HTL Techniques">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Advanced HTL Techniques"
+                    jcr:description="Deep dive into HTL templating"
+                    sessionTime="11:00 AM"
+                    presenterName="Bob Jones"
+                    presenterPath="/content/sites/signal-conf/presenters/bob-jones"
+                    kes:tags="[/etc/tags/signal-conf/day-1,/etc/tags/signal-conf/topic/htl]">
+                <related-sessions
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                        kes:datasource="tag-search"
+                        pagesPath="/content/sites/signal-conf/sessions"
+                        readMoreText="View Session"/>
+            </jcr:content>
+        </advanced-htl>
+        <osgi-services
+                jcr:primaryType="kes:Page"
+                jcr:title="OSGi Services Deep Dive">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="OSGi Services Deep Dive"
+                    jcr:description="Understanding OSGi service patterns"
+                    sessionTime="2:00 PM"
+                    presenterName="Alice Smith"
+                    presenterPath="/content/sites/signal-conf/presenters/alice-smith"
+                    kes:tags="[/etc/tags/signal-conf/day-2,/etc/tags/signal-conf/topic/sling]">
+                <related-sessions
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                        kes:datasource="tag-search"
+                        pagesPath="/content/sites/signal-conf/sessions"
+                        readMoreText="View Session"/>
+            </jcr:content>
+        </osgi-services>
+    </sessions>
+    <schedule
+            jcr:primaryType="kes:Page"
+            jcr:title="Schedule">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Schedule"
+                jcr:description="Conference schedule">
+            <day-1-table
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="/libs/kestros/commons/components/content/table"
+                    kes:datasource="schedule"
+                    sessionsPath="/content/sites/signal-conf/sessions"
+                    dayTag="/etc/tags/signal-conf/day-1"/>
+            <day-2-table
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="/libs/kestros/commons/components/content/table"
+                    kes:datasource="schedule"
+                    sessionsPath="/content/sites/signal-conf/sessions"
+                    dayTag="/etc/tags/signal-conf/day-2"/>
+        </jcr:content>
+    </schedule>
+</jcr:root>

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/ButtonGroupPresenterSessionsDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/ButtonGroupPresenterSessionsDataSource.java
@@ -1,0 +1,105 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.content.KestrosButton;
+import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.LinkUtils;
+import io.kestros.cms.components.basic.core.content.button.KestrosButtonImpl;
+import io.kestros.cms.sitebuilding.api.models.BaseComponent;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import io.kestros.cms.componenttypes.api.models.ComponentVariation;
+import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class ButtonGroupPresenterSessionsDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosButtonGroup {
+
+  private BaseContentPage containingPage;
+
+  BaseContentPage getContainingPage() {
+    if (containingPage == null) {
+      try {
+        BaseComponent component = getResource().adaptTo(BaseComponent.class);
+        if (component != null) {
+          containingPage = component.getContainingPage();
+        }
+      } catch (NoValidAncestorException e) {
+        return null;
+      }
+    }
+    return containingPage;
+  }
+
+  String getSessionsPath() {
+    return getResource().getValueMap().get("sessionsPath", String.class);
+  }
+
+  List<BaseContentPage> getPresenterSessions() {
+    List<BaseContentPage> sessions = new ArrayList<>();
+    String sessionsPath = getSessionsPath();
+    BaseContentPage presenterPage = getContainingPage();
+
+    if (sessionsPath == null || presenterPage == null) {
+      return sessions;
+    }
+
+    Resource sessionsResource = getResourceResolver().getResource(sessionsPath);
+    if (sessionsResource == null) {
+      return sessions;
+    }
+
+    BaseContentPage sessionsRoot = sessionsResource.adaptTo(BaseContentPage.class);
+    if (sessionsRoot == null) {
+      return sessions;
+    }
+
+    String presenterPath = presenterPage.getPath();
+
+    for (BaseContentPage sessionPage : sessionsRoot.getChildPages()) {
+      String sessionPresenter = sessionPage.getProperty("presenterPath", "");
+      if (presenterPath.equals(sessionPresenter)) {
+        sessions.add(sessionPage);
+      }
+    }
+
+    return sessions;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosButton> getButtonsElements() {
+    List<KestrosButton> buttons = new ArrayList<>();
+    int buttonIndex = 0;
+    for (BaseContentPage session : getPresenterSessions()) {
+      try {
+        buttons.add(
+            new KestrosButtonImpl(
+                session.getDisplayTitle(),
+                LinkUtils.getLink(session.getPath()),
+                null,
+                AnchorTarget.SAME_WINDOW,
+                null, null, null, null, false,
+                this,
+                "button",
+                "session-" + buttonIndex));
+        buttonIndex++;
+      } catch (Exception e) {
+        // Skip buttons that fail to construct — null-safe
+      }
+    }
+    return new ArrayList<>(buttons);
+  }
+
+  @Nonnull
+  @Override
+  public List<ComponentVariation> getButtonVariations() {
+    return getElementVariations("button", KestrosButton.RESOURCE_TYPE);
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/CardListPresentersDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/CardListPresentersDataSource.java
@@ -1,0 +1,63 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class CardListPresentersDataSource extends BaseContainerSlingModelDataSource implements
+                                                                                    KestrosCardList {
+
+  private BaseContentPage rootPage;
+
+  BaseContentPage getRootPage() {
+    if (rootPage == null) {
+      String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
+      if (pagesPath != null) {
+        Resource pageResource = getResourceResolver().getResource(pagesPath);
+        if (pageResource != null) {
+          rootPage = pageResource.adaptTo(BaseContentPage.class);
+        }
+      }
+    }
+    return rootPage;
+  }
+
+  @Nullable
+  public String getReadMoreText() {
+    return getResource().getValueMap().get("readMoreText", String.class);
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosCard> getCardElements() {
+    List<KestrosCard> cards = new ArrayList<>();
+    BaseContentPage root = getRootPage();
+    if (root == null) {
+      return cards;
+    }
+
+    for (BaseContentPage page : root.getChildPages()) {
+      try {
+        cards.add(
+            new KestrosCardImpl(page,
+                getReadMoreText(),
+                this,
+                "card",
+                page.getName()));
+      } catch (Exception e) {
+        // Skip cards that fail to construct — null-safe
+      }
+    }
+    return new ArrayList<>(cards);
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableCell.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableCell.java
@@ -1,0 +1,35 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SyntheticTableCell extends BaseContainerSyntheticResource implements KestrosTableCell {
+
+  private final String text;
+
+  public SyntheticTableCell(@Nonnull String text,
+      @Nonnull BaseSlingModelDataSource dataSource,
+      @Nonnull String resourcePrefix,
+      @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = text;
+  }
+
+  @Nullable
+  public String getText() {
+    return text;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getCellContentElements() {
+    return new ArrayList<>();
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableHeader.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableHeader.java
@@ -1,0 +1,27 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import io.kestros.cms.components.basic.core.BaseSyntheticResource;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SyntheticTableHeader extends BaseSyntheticResource implements KestrosTableHeader {
+
+  private final String text;
+
+  public SyntheticTableHeader(@Nonnull String text,
+      @Nonnull BaseSlingModelDataSource dataSource,
+      @Nonnull String resourcePrefix,
+      @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = text;
+  }
+
+  @Nullable
+  @Override
+  public String getText() {
+    return text;
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableRow.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableRow.java
@@ -1,0 +1,37 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SyntheticTableRow extends BaseContainerSyntheticResource implements KestrosTableRow {
+
+  private final List<KestrosTableCell> cells;
+
+  public SyntheticTableRow(@Nonnull List<KestrosTableCell> cells,
+      @Nonnull BaseSlingModelDataSource dataSource,
+      @Nonnull String resourcePrefix,
+      @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.cells = cells;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableCell> getCellElements() {
+    return new ArrayList<>(cells);
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(cells);
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/TableScheduleDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/TableScheduleDataSource.java
@@ -1,0 +1,113 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import io.kestros.cms.tagging.api.models.KestrosTag;
+import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class TableScheduleDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosTable {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private TagRetrievalService tagRetrievalService;
+
+  String getDayTag() {
+    return getResource().getValueMap().get("dayTag", String.class);
+  }
+
+  String getSessionsPath() {
+    return getResource().getValueMap().get("sessionsPath", String.class);
+  }
+
+  List<BaseContentPage> getSessionsForDay() {
+    List<BaseContentPage> sessions = new ArrayList<>();
+    String dayTag = getDayTag();
+    String sessionsPath = getSessionsPath();
+
+    if (dayTag == null || sessionsPath == null || tagRetrievalService == null) {
+      return sessions;
+    }
+
+    Resource sessionsResource = getResourceResolver().getResource(sessionsPath);
+    if (sessionsResource == null) {
+      return sessions;
+    }
+
+    BaseContentPage sessionsPage = sessionsResource.adaptTo(BaseContentPage.class);
+    if (sessionsPage == null) {
+      return sessions;
+    }
+
+    for (BaseContentPage sessionPage : sessionsPage.getChildPages()) {
+      List<KestrosTag> tags = tagRetrievalService.getTagsOnResource(sessionPage.getResource());
+      for (KestrosTag tag : tags) {
+        if (dayTag.equals(tag.getPath())) {
+          sessions.add(sessionPage);
+          break;
+        }
+      }
+    }
+    return sessions;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableHeader> getHeaderElements() {
+    List<KestrosTableHeader> headers = new ArrayList<>();
+    try {
+      headers.add(new SyntheticTableHeader("Time", this, "header", "time-header"));
+      headers.add(new SyntheticTableHeader("Session", this, "header", "session-header"));
+      headers.add(new SyntheticTableHeader("Presenter", this, "header", "presenter-header"));
+    } catch (Exception e) {
+      // Return empty headers on error — null-safe
+    }
+    return headers;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableRow> getRowElements() {
+    List<KestrosTableRow> rows = new ArrayList<>();
+    int rowIndex = 0;
+    for (BaseContentPage session : getSessionsForDay()) {
+      try {
+        String time = session.getProperty("sessionTime", "");
+        String title = session.getDisplayTitle();
+        String presenter = session.getProperty("presenterName", "");
+
+        List<KestrosTableCell> cells = Arrays.asList(
+            new SyntheticTableCell(time, this, "cell", "time-" + rowIndex),
+            new SyntheticTableCell(title, this, "cell", "session-" + rowIndex),
+            new SyntheticTableCell(presenter, this, "cell", "presenter-" + rowIndex)
+        );
+
+        rows.add(new SyntheticTableRow(cells, this, "row", "row-" + rowIndex));
+        rowIndex++;
+      } catch (Exception e) {
+        // Skip rows that fail to construct — null-safe
+      }
+    }
+    return rows;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(getRowElements());
+  }
+}

--- a/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/presenter-sessions.json
+++ b/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/presenter-sessions.json
@@ -1,0 +1,28 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Presenter Sessions",
+  "group": "Signal Conf",
+  "classPath": "io.kestros.samples.signalconf.datasources.ButtonGroupPresenterSessionsDataSource",
+  "container": true,
+  "edit": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/cms2/dialog",
+    "content": {
+      "jcr:primaryType": "nt:unstructured",
+      "sessions-path": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/pathfield",
+        "label": "Sessions Path",
+        "name": "sessionsPath",
+        "includePaths": [
+          "closest:kes:Site"
+        ],
+        "resourceTypes": [
+          "kes:Site",
+          "kes:Page"
+        ],
+        "autofocus": false
+      }
+    }
+  }
+}

--- a/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/presenters.json
+++ b/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/presenters.json
@@ -1,0 +1,35 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Presenters",
+  "group": "Signal Conf",
+  "classPath": "io.kestros.samples.signalconf.datasources.CardListPresentersDataSource",
+  "container": true,
+  "edit": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/cms2/dialog",
+    "content": {
+      "jcr:primaryType": "nt:unstructured",
+      "pages-path": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/pathfield",
+        "label": "Presenters Path",
+        "name": "pagesPath",
+        "includePaths": [
+          "closest:kes:Site"
+        ],
+        "resourceTypes": [
+          "kes:Site",
+          "kes:Page"
+        ],
+        "autofocus": false
+      },
+      "readMoreText": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Read More Text",
+        "name": "readMoreText",
+        "autofocus": false
+      }
+    }
+  }
+}

--- a/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/schedule.json
+++ b/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/schedule.json
@@ -1,0 +1,41 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Schedule",
+  "group": "Signal Conf",
+  "classPath": "io.kestros.samples.signalconf.datasources.TableScheduleDataSource",
+  "container": true,
+  "edit": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/cms2/dialog",
+    "content": {
+      "jcr:primaryType": "nt:unstructured",
+      "sessions-path": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/pathfield",
+        "label": "Sessions Path",
+        "name": "sessionsPath",
+        "includePaths": [
+          "closest:kes:Site"
+        ],
+        "resourceTypes": [
+          "kes:Site",
+          "kes:Page"
+        ],
+        "autofocus": false
+      },
+      "day-tag": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/pathfield",
+        "label": "Day Tag",
+        "name": "dayTag",
+        "includePaths": [
+          "/etc/tags"
+        ],
+        "resourceTypes": [
+          "kes:Tag"
+        ],
+        "autofocus": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements TASK-223: Creates 4 custom Java datasource classes for the signal-conf sample site in `kestros-sample-sites`.

Builds on the existing PR #29 branch (`feat/TASK-040-signal-conf-custom-datasources`) which had the near-complete implementation. This PR adds a critical bug fix to that work.

### What's included

**Java datasource classes** (`signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/`):
- `CardListPresentersDataSource` — renders child presenter pages as card-list (registered as `presenters`)
- `TableScheduleDataSource` — builds schedule table filtered by day tag (registered as `schedule`)
- `ButtonGroupPresenterSessionsDataSource` — inverse link: returns sessions for a presenter by matching `presenterPath` (registered as `presenter-sessions`)
- `SyntheticTableRow`, `SyntheticTableCell`, `SyntheticTableHeader` — synthetic support classes

**Datasource JSON registrations** (`signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/`):
- `presenters.json`, `schedule.json`, `presenter-sessions.json`

**Site content** (`signal-conf/src/content/jcr_root/content/sites/signal-conf/`):
- 2 presenter pages (alice-smith, bob-jones) with `presenter-sessions` button-groups
- 3 session pages (intro-to-sling, advanced-htl, osgi-services) with `tag-search` related-sessions
- Schedule page with day-1 and day-2 `schedule` table components

**Bug fix** (`signal-conf/pom.xml`):
- Removed `/content/sites` from bundle `Sling-Initial-Content` — the bundle was creating the site root as `sling:Folder` which conflicted with the vault package trying to create it as `kes:Site`. Content deployment is now exclusively handled by the vault package (the `.zip` artifact).
- Made `Sling-Model-Packages` explicit in the bundle manifest (previously auto-inferred; now explicit for reliability).

### Deployment verification

- Bundle `io.kestros.samples.signal-conf v0.0.1.SNAPSHOT` is Active at port 8000
- All 3 datasource registrations confirmed in JCR at `/libs/kestros/samples/signal-conf/datasources/`
- Site content structure deployed at `/content/sites/signal-conf/` (kes:Site type)
- Tag nodes created at `/etc/tags/signal-conf/day-1` and `/etc/tags/signal-conf/day-2`
- `TagRetrievalService` is Active (required for `TableScheduleDataSource`)
- No NullPointerException or closed-resolver errors in CMS error log

### Note on content deployment

The vault package (`.zip`) must be installed separately to deploy site content. The bundle alone handles datasource registrations and Java classes. See deployment steps in TASK-223 technical guidelines.