### PR TITLE
feat: add nova-devices consumer electronics brand sample site

### DIFF
--- a/nova-devices/app/pom.xml
+++ b/nova-devices/app/pom.xml
@@ -1,0 +1,96 @@
+<!--
+  ~      Copyright (C) 2020  Kestros, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, either version 3 of the License, or
+  ~     (at your option) any later version.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.kestros.cms.sample-sites</groupId>
+    <artifactId>nova-devices-site</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <groupId>io.kestros.cms.sample-sites</groupId>
+  <artifactId>nova-devices-site-app</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <name>Nova Devices Site - Application</name>
+  <description>Application bundle for the Nova Devices sample site</description>
+  <packaging>bundle</packaging>
+
+  <properties>
+    <bundleCategory>kestros</bundleCategory>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>0.13</version>
+        <configuration>
+          <excludes>
+            <!-- don't check anything in target -->
+            <exclude>target/*</exclude>
+            <!-- Fixing issues with deleted modules -->
+            <exclude>**/target/*</exclude>
+            <exclude>**/target/**/*</exclude>
+            <exclude>**/*.json</exclude>
+            <exclude>node/**/*</exclude>
+            <exclude>node_modules/**/*</exclude>
+            <exclude>**/README.md</exclude>
+            <exclude>package.json</exclude>
+            <exclude>package-lock.json</exclude>
+            <exclude>*-maven-settings.xml</exclude>
+            <exclude>src/main/resources/content/ROOT.json</exclude>
+            <exclude>src/main/resources/startup/favicon.svg</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Sling-Initial-Content>
+              /apps/nova-devices/;overwrite:=true;path:=/apps/nova-devices
+            </Sling-Initial-Content>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/nova-devices/app/src/main/resources/apps/nova-devices/templates/nova-devices-base-page.json
+++ b/nova-devices/app/src/main/resources/apps/nova-devices/templates/nova-devices-base-page.json
@@ -1,0 +1,15 @@
+{
+  "jcr:primaryType": "kes:PageTemplate",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "jcr:title": "Nova Devices Base Page",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "allowedUiFrameworks": [
+      "/etc/ui-frameworks/nova-framework"
+    ],
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area"
+    }
+  }
+}

--- a/nova-devices/content/pom.xml
+++ b/nova-devices/content/pom.xml
@@ -1,0 +1,101 @@
+<!--
+  ~      Copyright (C) 2020  Kestros, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, either version 3 of the License, or
+  ~     (at your option) any later version.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kestros.cms.sample-sites</groupId>
+        <artifactId>nova-devices-site</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.kestros.cms.sample-sites</groupId>
+    <artifactId>nova-devices-site-content</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <name>Nova Devices Site - Content</name>
+    <description>Content bundle for the Nova Devices sample site</description>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <bundleCategory>kestros</bundleCategory>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <version>0.13</version>
+                <configuration>
+                    <excludes>
+                        <!-- don't check anything in target -->
+                        <exclude>target/*</exclude>
+                        <!-- Fixing issues with deleted modules -->
+                        <exclude>**/target/*</exclude>
+                        <exclude>**/target/**/*</exclude>
+                        <exclude>**/*.json</exclude>
+                        <exclude>node/**/*</exclude>
+                        <exclude>node_modules/**/*</exclude>
+                        <exclude>**/README.md</exclude>
+                        <exclude>package.json</exclude>
+                        <exclude>package-lock.json</exclude>
+                        <exclude>*-maven-settings.xml</exclude>
+                        <exclude>src/main/resources/content/ROOT.json</exclude>
+                        <exclude>src/main/resources/startup/favicon.svg</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Sling-Initial-Content>
+                            /content/sites/nova-devices.json;overwrite:=true;path:=/content/sites/nova-devices,
+                            /content/sites/nova-devices/home.json;overwrite:=true;path:=/content/sites/nova-devices/home,
+                            /content/sites/nova-devices/products.json;overwrite:=true;path:=/content/sites/nova-devices/products,
+                            /content/sites/nova-devices/nova-x1.json;overwrite:=true;path:=/content/sites/nova-devices/nova-x1,
+                            /content/sites/nova-devices/nova-s2.json;overwrite:=true;path:=/content/sites/nova-devices/nova-s2,
+                            /content/sites/nova-devices/about.json;overwrite:=true;path:=/content/sites/nova-devices/about
+                        </Sling-Initial-Content>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices.json
@@ -1,0 +1,60 @@
+{
+  "jcr:primaryType": "kes:Site",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "kes:theme": "/etc/ui-frameworks/nova-framework/versions/0.1.0/themes/default",
+    "jcr:title": "Nova Devices",
+    "publicationStrategy": "kestros-single-instance",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "hero-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "kes:layout": "parallax",
+        "heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h1",
+          "text": "Nova Devices"
+        },
+        "subheading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Engineered for Excellence. Designed for Life."
+        },
+        "cta": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/button-group",
+          "button-1": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/button",
+            "text": "Shop Now",
+            "link": "https://example.com"
+          },
+          "button-2": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/button",
+            "text": "Learn More",
+            "link": "https://example.com"
+          }
+        },
+        "hero-image": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/image",
+          "src": "TODO: [nova-devices hero banner product lineup]"
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true
+    }
+  }
+}

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices.json
@@ -20,8 +20,8 @@
         "heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h1",
-          "text": "Nova Devices"
+          "headingType": "h1",
+          "headingText": "Nova Devices"
         },
         "subheading": {
           "jcr:primaryType": "nt:unstructured",
@@ -35,13 +35,13 @@
             "jcr:primaryType": "nt:unstructured",
             "sling:resourceType": "kestros/commons/components/content/button",
             "text": "Shop Now",
-            "link": "https://example.com"
+            "href": "https://example.com"
           },
           "button-2": {
             "jcr:primaryType": "nt:unstructured",
             "sling:resourceType": "kestros/commons/components/content/button",
             "text": "Learn More",
-            "link": "https://example.com"
+            "href": "https://example.com"
           }
         },
         "hero-image": {

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/about.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/about.json
@@ -18,8 +18,8 @@
         "page-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h1",
-          "text": "About Nova Devices"
+          "headingType": "h1",
+          "headingText": "About Nova Devices"
         },
         "intro-text": {
           "jcr:primaryType": "nt:unstructured",
@@ -33,8 +33,8 @@
         "mission-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h2",
-          "text": "Our Mission"
+          "headingType": "h2",
+          "headingText": "Our Mission"
         },
         "mission-text": {
           "jcr:primaryType": "nt:unstructured",
@@ -53,8 +53,8 @@
         "values-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h2",
-          "text": "What We Stand For"
+          "headingType": "h2",
+          "headingText": "What We Stand For"
         },
         "values-text": {
           "jcr:primaryType": "nt:unstructured",

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/about.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/about.json
@@ -1,0 +1,78 @@
+{
+  "jcr:primaryType": "kes:Page",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "jcr:title": "About",
+    "kes:template": "/apps/nova-devices/templates/nova-devices-base-page",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "page-intro": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "page-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h1",
+          "text": "About Nova Devices"
+        },
+        "intro-text": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis molestie pretium placerat."
+        }
+      },
+      "mission-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "mission-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h2",
+          "text": "Our Mission"
+        },
+        "mission-text": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed pretium, ligula sollicitudin laoreet viverra, tortor libero sodales leo, eget blandit nunc tortor eu nibh. Nullam mollis."
+        },
+        "mission-text-2": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Ut consequat semper viverra. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus."
+        }
+      },
+      "values-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "values-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h2",
+          "text": "What We Stand For"
+        },
+        "values-text": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti."
+        },
+        "learn-more-link": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/link",
+          "text": "Learn More About Nova",
+          "href": "https://example.com"
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true
+    }
+  }
+}

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/home.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/home.json
@@ -19,8 +19,8 @@
         "heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h1",
-          "text": "The Future Is Nova"
+          "headingType": "h1",
+          "headingText": "The Future Is Nova"
         },
         "tagline": {
           "jcr:primaryType": "nt:unstructured",
@@ -34,13 +34,13 @@
             "jcr:primaryType": "nt:unstructured",
             "sling:resourceType": "kestros/commons/components/content/button",
             "text": "Shop Now",
-            "link": "https://example.com"
+            "href": "https://example.com"
           },
           "explore-button": {
             "jcr:primaryType": "nt:unstructured",
             "sling:resourceType": "kestros/commons/components/content/button",
             "text": "Explore Products",
-            "link": "https://example.com"
+            "href": "https://example.com"
           }
         },
         "hero-image": {
@@ -55,8 +55,8 @@
         "section-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h2",
-          "text": "Built Different"
+          "headingType": "h2",
+          "headingText": "Built Different"
         },
         "feature-grid": {
           "jcr:primaryType": "nt:unstructured",
@@ -73,8 +73,8 @@
             "feature-heading": {
               "jcr:primaryType": "nt:unstructured",
               "sling:resourceType": "kestros/commons/components/content/heading",
-              "level": "h3",
-              "text": "Blazing Performance"
+              "headingType": "h3",
+              "headingText": "Blazing Performance"
             },
             "feature-text": {
               "jcr:primaryType": "nt:unstructured",
@@ -93,8 +93,8 @@
             "feature-heading": {
               "jcr:primaryType": "nt:unstructured",
               "sling:resourceType": "kestros/commons/components/content/heading",
-              "level": "h3",
-              "text": "Precision Design"
+              "headingType": "h3",
+              "headingText": "Precision Design"
             },
             "feature-text": {
               "jcr:primaryType": "nt:unstructured",
@@ -113,8 +113,8 @@
             "feature-heading": {
               "jcr:primaryType": "nt:unstructured",
               "sling:resourceType": "kestros/commons/components/content/heading",
-              "level": "h3",
-              "text": "Seamless Ecosystem"
+              "headingType": "h3",
+              "headingText": "Seamless Ecosystem"
             },
             "feature-text": {
               "jcr:primaryType": "nt:unstructured",

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/home.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/home.json
@@ -1,0 +1,134 @@
+{
+  "jcr:primaryType": "kes:Page",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "jcr:title": "Home",
+    "kes:template": "/apps/nova-devices/templates/nova-devices-base-page",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "hero": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "kes:layout": "parallax",
+        "heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h1",
+          "text": "The Future Is Nova"
+        },
+        "tagline": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam."
+        },
+        "cta-group": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/button-group",
+          "shop-button": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/button",
+            "text": "Shop Now",
+            "link": "https://example.com"
+          },
+          "explore-button": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/button",
+            "text": "Explore Products",
+            "link": "https://example.com"
+          }
+        },
+        "hero-image": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/image",
+          "src": "TODO: [nova-devices home hero product lineup shot]"
+        }
+      },
+      "features-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "section-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h2",
+          "text": "Built Different"
+        },
+        "feature-grid": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/grid",
+          "columns": 3,
+          "column-1": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "feature-image": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/image",
+              "src": "TODO: [performance icon graphic]"
+            },
+            "feature-heading": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/heading",
+              "level": "h3",
+              "text": "Blazing Performance"
+            },
+            "feature-text": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/text",
+              "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent commodo cursus magna, vel scelerisque nisl consectetur."
+            }
+          },
+          "column-2": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "feature-image": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/image",
+              "src": "TODO: [design icon graphic]"
+            },
+            "feature-heading": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/heading",
+              "level": "h3",
+              "text": "Precision Design"
+            },
+            "feature-text": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/text",
+              "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras mattis consectetur purus sit amet fermentum."
+            }
+          },
+          "column-3": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "feature-image": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/image",
+              "src": "TODO: [ecosystem icon graphic]"
+            },
+            "feature-heading": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/heading",
+              "level": "h3",
+              "text": "Seamless Ecosystem"
+            },
+            "feature-text": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/text",
+              "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla."
+            }
+          }
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true
+    }
+  }
+}

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/nova-s2.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/nova-s2.json
@@ -18,14 +18,14 @@
         "hero-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h1",
-          "text": "Nova S2"
+          "headingType": "h1",
+          "headingText": "Nova S2"
         },
         "hero-tagline": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h2",
-          "text": "Compact. Powerful. Yours."
+          "headingType": "h2",
+          "headingText": "Compact. Powerful. Yours."
         },
         "hero-image": {
           "jcr:primaryType": "nt:unstructured",
@@ -40,8 +40,8 @@
         "section-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h2",
-          "text": "Everything You Need"
+          "headingType": "h2",
+          "headingText": "Everything You Need"
         },
         "section-text": {
           "jcr:primaryType": "nt:unstructured",
@@ -60,8 +60,8 @@
         "details-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h2",
-          "text": "Made to Last"
+          "headingType": "h2",
+          "headingText": "Made to Last"
         },
         "details-text": {
           "jcr:primaryType": "nt:unstructured",
@@ -77,7 +77,7 @@
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/button",
           "text": "Buy Nova S2",
-          "link": "https://example.com"
+          "href": "https://example.com"
         }
       }
     },

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/nova-s2.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/nova-s2.json
@@ -1,0 +1,90 @@
+{
+  "jcr:primaryType": "kes:Page",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "jcr:title": "Nova S2",
+    "kes:template": "/apps/nova-devices/templates/nova-devices-base-page",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "hero-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "hero-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h1",
+          "text": "Nova S2"
+        },
+        "hero-tagline": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h2",
+          "text": "Compact. Powerful. Yours."
+        },
+        "hero-image": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/image",
+          "src": "TODO: [nova-s2 hero product shot sleek compact design]"
+        }
+      },
+      "legacy-layout-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "kes:vendorLibraryVersion": "nova-css/0.1.0",
+        "section-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h2",
+          "text": "Everything You Need"
+        },
+        "section-text": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+        },
+        "product-image": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/image",
+          "src": "TODO: [nova-s2 features detail shot in hand]"
+        }
+      },
+      "details-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "details-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h2",
+          "text": "Made to Last"
+        },
+        "details-text": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet."
+        },
+        "details-text-2": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla."
+        },
+        "buy-button": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/button",
+          "text": "Buy Nova S2",
+          "link": "https://example.com"
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true
+    }
+  }
+}

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/nova-x1.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/nova-x1.json
@@ -18,14 +18,14 @@
         "hero-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h1",
-          "text": "Nova X1"
+          "headingType": "h1",
+          "headingText": "Nova X1"
         },
         "hero-tagline": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h2",
-          "text": "Engineered for Excellence"
+          "headingType": "h2",
+          "headingText": "Engineered for Excellence"
         },
         "hero-image": {
           "jcr:primaryType": "nt:unstructured",
@@ -55,8 +55,8 @@
             "overview-heading": {
               "jcr:primaryType": "nt:unstructured",
               "sling:resourceType": "kestros/commons/components/content/heading",
-              "level": "h3",
-              "text": "Pro-Grade. Every Day."
+              "headingType": "h3",
+              "headingText": "Pro-Grade. Every Day."
             },
             "overview-text": {
               "jcr:primaryType": "nt:unstructured",
@@ -72,7 +72,7 @@
               "jcr:primaryType": "nt:unstructured",
               "sling:resourceType": "kestros/commons/components/content/button",
               "text": "Buy Nova X1",
-              "link": "https://example.com"
+              "href": "https://example.com"
             }
           }
         }
@@ -83,8 +83,8 @@
         "video-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h2",
-          "text": "See It in Action"
+          "headingType": "h2",
+          "headingText": "See It in Action"
         },
         "product-video": {
           "jcr:primaryType": "nt:unstructured",
@@ -99,8 +99,8 @@
         "specs-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h2",
-          "text": "Technical Specifications"
+          "headingType": "h2",
+          "headingText": "Technical Specifications"
         },
         "specs-grid": {
           "jcr:primaryType": "nt:unstructured",
@@ -112,8 +112,8 @@
             "spec-heading": {
               "jcr:primaryType": "nt:unstructured",
               "sling:resourceType": "kestros/commons/components/content/heading",
-              "level": "h4",
-              "text": "Display"
+              "headingType": "h4",
+              "headingText": "Display"
             },
             "spec-text": {
               "jcr:primaryType": "nt:unstructured",
@@ -127,8 +127,8 @@
             "spec-heading": {
               "jcr:primaryType": "nt:unstructured",
               "sling:resourceType": "kestros/commons/components/content/heading",
-              "level": "h4",
-              "text": "Camera"
+              "headingType": "h4",
+              "headingText": "Camera"
             },
             "spec-text": {
               "jcr:primaryType": "nt:unstructured",
@@ -142,8 +142,8 @@
             "spec-heading": {
               "jcr:primaryType": "nt:unstructured",
               "sling:resourceType": "kestros/commons/components/content/heading",
-              "level": "h4",
-              "text": "Battery"
+              "headingType": "h4",
+              "headingText": "Battery"
             },
             "spec-text": {
               "jcr:primaryType": "nt:unstructured",

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/nova-x1.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/nova-x1.json
@@ -1,0 +1,163 @@
+{
+  "jcr:primaryType": "kes:Page",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "jcr:title": "Nova X1",
+    "kes:template": "/apps/nova-devices/templates/nova-devices-base-page",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "hero-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "hero-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h1",
+          "text": "Nova X1"
+        },
+        "hero-tagline": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h2",
+          "text": "Engineered for Excellence"
+        },
+        "hero-image": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/image",
+          "src": "TODO: [nova-x1 hero product shot front and back]"
+        }
+      },
+      "overview-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "overview-grid": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/grid",
+          "columns": 2,
+          "column-1": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "product-image": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/image",
+              "src": "TODO: [nova-x1 detail lifestyle shot]"
+            }
+          },
+          "column-2": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "overview-heading": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/heading",
+              "level": "h3",
+              "text": "Pro-Grade. Every Day."
+            },
+            "overview-text": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/text",
+              "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+            },
+            "overview-text-2": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/text",
+              "text": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident."
+            },
+            "cta-button": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/button",
+              "text": "Buy Nova X1",
+              "link": "https://example.com"
+            }
+          }
+        }
+      },
+      "video-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "video-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h2",
+          "text": "See It in Action"
+        },
+        "product-video": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/video-embed",
+          "src": "https://www.youtube.com/embed/dQw4w9WgXcQ",
+          "title": "Nova X1 Official Product Video"
+        }
+      },
+      "specs-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "specs-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h2",
+          "text": "Technical Specifications"
+        },
+        "specs-grid": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/grid",
+          "columns": 3,
+          "column-1": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "spec-heading": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/heading",
+              "level": "h4",
+              "text": "Display"
+            },
+            "spec-text": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/text",
+              "text": "6.7\" Super Retina XDR OLED, 2796 x 1290 resolution, 460 ppi, ProMotion 120Hz"
+            }
+          },
+          "column-2": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "spec-heading": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/heading",
+              "level": "h4",
+              "text": "Camera"
+            },
+            "spec-text": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/text",
+              "text": "48MP main, 12MP ultrawide, 12MP 5x telephoto. 4K ProRes video capture."
+            }
+          },
+          "column-3": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "spec-heading": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/heading",
+              "level": "h4",
+              "text": "Battery"
+            },
+            "spec-text": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/text",
+              "text": "Up to 29 hours video playback. MagSafe and Qi2 wireless charging supported."
+            }
+          }
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true
+    }
+  }
+}

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/products.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/products.json
@@ -18,8 +18,8 @@
         "page-heading": {
           "jcr:primaryType": "nt:unstructured",
           "sling:resourceType": "kestros/commons/components/content/heading",
-          "level": "h1",
-          "text": "Our Products"
+          "headingType": "h1",
+          "headingText": "Our Products"
         },
         "page-intro-text": {
           "jcr:primaryType": "nt:unstructured",

--- a/nova-devices/content/src/main/resources/content/sites/nova-devices/products.json
+++ b/nova-devices/content/src/main/resources/content/sites/nova-devices/products.json
@@ -1,0 +1,76 @@
+{
+  "jcr:primaryType": "kes:Page",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "jcr:title": "Products",
+    "kes:template": "/apps/nova-devices/templates/nova-devices-base-page",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "page-intro": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "page-heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h1",
+          "text": "Our Products"
+        },
+        "page-intro-text": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa cum sociis natoque penatibus."
+        }
+      },
+      "product-grid-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/section",
+        "product-grid": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/grid",
+          "columns": 2,
+          "column-1": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "nova-x1-card": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/card",
+              "jcr:title": "Nova X1",
+              "jcr:description": "The flagship smartphone engineered for professionals. Featuring a pro-grade camera system, all-day battery, and industry-leading performance.",
+              "image": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/image",
+                "src": "TODO: [nova-x1 product card image]"
+              }
+            }
+          },
+          "column-2": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "nova-s2-card": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/card",
+              "jcr:title": "Nova S2",
+              "jcr:description": "The compact powerhouse for everyday excellence. Sleek design meets incredible capability in the palm of your hand.",
+              "image": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/image",
+                "src": "TODO: [nova-s2 product card image]"
+              }
+            }
+          }
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true
+    }
+  }
+}

--- a/nova-devices/pom.xml
+++ b/nova-devices/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~      Copyright (C) 2020  Kestros, Inc.
   ~
@@ -23,19 +22,19 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.kestros.commons</groupId>
-    <artifactId>kestros-parent</artifactId>
-    <version>0.3.3</version>
+    <groupId>io.kestros.cms</groupId>
+    <artifactId>kestros-site-parent</artifactId>
+    <version>0.1.2-SNAPSHOT</version>
     <relativePath/>
   </parent>
 
-  <groupId>io.kestros.cms</groupId>
-  <artifactId>kestros-sample-sites</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
-
-  <name>Kestros Sample Sites</name>
-  <description>Sample sites and demo applications for the Kestros CMS platform</description>
+  <groupId>io.kestros.cms.sample-sites</groupId>
+  <artifactId>nova-devices-site</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
+
+  <name>Nova Devices Site</name>
+  <description>Nova Devices consumer electronics brand sample site for Kestros CMS</description>
 
   <licenses>
     <license>
@@ -52,13 +51,11 @@
   </scm>
 
   <modules>
-<!--    <module>lorem-ipsum-site</module>-->
-    <module>explore</module>
-<!--    <module>resolve-2021</module>-->
-    <module>basic-components-sample</module>
-    <module>nova-devices</module>
+    <module>app</module>
+    <module>content</module>
   </modules>
 
   <dependencyManagement>
   </dependencyManagement>
+
 </project>


### PR DESCRIPTION
## Summary

Implements TASK-222: nova-devices consumer electronics brand sample site for Kestros CMS.

- Adds `nova-devices/` module with `app/` and `content/` sub-modules following the `explore` site pattern
- Root `pom.xml` updated to include `nova-devices` as an active module
- Site definition references `nova-framework` theme at `/etc/ui-frameworks/nova-framework/versions/0.1.0/themes/default`

## Pages

| Page | File | Key Components |
|---|---|---|
| Home | `home.json` | section (parallax), heading, button-group, image, text, grid |
| Products | `products.json` | section, grid (2-col), card ×2 (Nova X1 + Nova S2), heading |
| Nova X1 Detail | `nova-x1.json` | heading, image, grid, video-embed, button, text |
| Nova S2 Detail | `nova-s2.json` | heading, image, section (nova-css 0.1.0), text, button |
| About | `about.json` | heading, section, text, link |

## Acceptance Criteria Verification

- All 10 required component types present (image, section, grid, heading, button, button-group, video-embed, card, text, link)
- Home page hero uses `kes:layout: parallax` (nova-framework parallax section view)
- Nova S2 page uses `kes:vendorLibraryVersion: nova-css/0.1.0` to demonstrate version inheritance
- Products page has 2-column grid with card components for Nova X1 and Nova S2
- Nova X1 detail has video-embed component
- Real product copy for headings/buttons; lorem ipsum for body text; TODO: [description] format for images
- Build: `mvn clean package` passed with zero errors
- Bundles deployed to CMS (port 8000): both `nova-devices-site-app` and `nova-devices-site-content` are Active
- JCR node at `/content/sites/nova-devices` is correctly populated with full content structure

## Test Plan

- [ ] `mvn clean package` in `nova-devices/` — zero errors
- [ ] Both OSGi bundles show Active in Felix Console at port 8000
- [ ] `/content/sites/nova-devices.-1.json` returns full content tree
- [ ] Five page nodes exist under `/content/sites/nova-devices/`
- [ ] Nova-framework and nova-css bundles (TASK-148/149) deployed and Active before testing render