### PR TITLE
feat: add dialog-field-sample test component (TASK-295)

### DIFF
--- a/basic-components-sample/pom.xml
+++ b/basic-components-sample/pom.xml
@@ -13,7 +13,7 @@
     <groupId>io.kestros.samples</groupId>
     <artifactId>basic-components-sample</artifactId>
 
-    <version>0.0.3</version>
+    <version>0.0.4-SNAPSHOT</version>
 
     <name>Basic Components Sample Site</name>
     <description>Sample site demonstrating Kestros basic components</description>

--- a/basic-components-sample/src/content/META-INF/vault/filter.xml
+++ b/basic-components-sample/src/content/META-INF/vault/filter.xml
@@ -2,5 +2,6 @@
 <workspaceFilter version="1.0">
 
   <filter root="/content/sites/basic-components-sample"/>
+  <filter root="/apps/kestros/samples"/>
 
 </workspaceFilter>

--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:kes="http://kestros.io/kes/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="kes:ComponentType"
+    jcr:title="Dialog Field Sample"
+    componentGroup="Kestros Samples"/>

--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
@@ -1,0 +1,25 @@
+<dl style="font-family: monospace; font-size: 12px; line-height: 1.8;">
+    <dt>textRequired</dt>       <dd>${properties.textRequired @ context='text'}</dd>
+    <dt>textOptional</dt>       <dd>${properties.textOptional @ context='text'}</dd>
+    <dt>textDisabled</dt>       <dd>${properties.textDisabled @ context='text'}</dd>
+    <dt>textareaValue</dt>      <dd>${properties.textareaValue @ context='text'}</dd>
+    <dt>textareaRequired</dt>   <dd>${properties.textareaRequired @ context='text'}</dd>
+    <dt>checkboxValue</dt>      <dd>${properties.checkboxValue @ context='text'}</dd>
+    <dt>checkboxDisabled</dt>   <dd>${properties.checkboxDisabled @ context='text'}</dd>
+    <dt>selectValue</dt>        <dd>${properties.selectValue @ context='text'}</dd>
+    <dt>selectRequired</dt>     <dd>${properties.selectRequired @ context='text'}</dd>
+    <dt>assetPath</dt>          <dd>${properties.assetPath @ context='text'}</dd>
+    <dt>pagePath</dt>           <dd>${properties.pagePath @ context='text'}</dd>
+    <dt>numberValue</dt>        <dd>${properties.numberValue @ context='text'}</dd>
+    <dt>numberRequired</dt>     <dd>${properties.numberRequired @ context='text'}</dd>
+    <dt>dateValue</dt>          <dd>${properties.dateValue @ context='text'}</dd>
+    <dt>datetimeValue</dt>      <dd>${properties.datetimeValue @ context='text'}</dd>
+    <dt>hiddenValue</dt>        <dd>${properties.hiddenValue @ context='text'}</dd>
+    <dt>toggleValue</dt>        <dd>${properties.toggleValue @ context='text'}</dd>
+    <dt>toggleDisabled</dt>     <dd>${properties.toggleDisabled @ context='text'}</dd>
+    <dt>radioValue</dt>         <dd>${properties.radioValue @ context='text'}</dd>
+    <dt>radioRequired</dt>      <dd>${properties.radioRequired @ context='text'}</dd>
+    <dt>tagValue</dt>           <dd>${properties.tagValue @ context='text'}</dd>
+    <dt>richTextValue</dt>      <dd>${properties.richTextValue @ context='html'}</dd>
+    <dt>multifieldItems</dt>    <dd>${properties.multifieldItems @ context='text'}</dd>
+</dl>

--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="nt:unstructured"
+    sling:resourceType="kestros/cms2/dialog">
+    <content
+        jcr:primaryType="nt:unstructured">
+
+        <text-required
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/textfield"
+            label="Text (Required)"
+            name="textRequired"
+            required="{Boolean}true"/>
+        <text-optional
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/textfield"
+            label="Text (Optional)"
+            name="textOptional"
+            required="{Boolean}false"/>
+        <text-disabled
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/textfield"
+            label="Text (Disabled)"
+            name="textDisabled"
+            required="{Boolean}false"
+            disabled="{Boolean}true"/>
+
+        <textarea-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/textarea"
+            label="Textarea"
+            name="textareaValue"
+            required="{Boolean}false"/>
+        <textarea-required
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/textarea"
+            label="Textarea (Required)"
+            name="textareaRequired"
+            required="{Boolean}true"/>
+
+        <checkbox-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/checkbox"
+            label="Checkbox"
+            name="checkboxValue"
+            required="{Boolean}false"/>
+        <checkbox-disabled
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/checkbox"
+            label="Checkbox (Disabled)"
+            name="checkboxDisabled"
+            required="{Boolean}false"
+            disabled="{Boolean}true"/>
+
+        <select-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/selectfield"
+            label="Select"
+            name="selectValue"
+            required="{Boolean}false">
+            <options jcr:primaryType="nt:unstructured">
+                <option-a
+                    jcr:primaryType="nt:unstructured"
+                    text="Option A"
+                    value="a"
+                    selected="{Boolean}true"/>
+                <option-b
+                    jcr:primaryType="nt:unstructured"
+                    text="Option B"
+                    value="b"
+                    selected="{Boolean}false"/>
+                <option-c
+                    jcr:primaryType="nt:unstructured"
+                    text="Option C"
+                    value="c"
+                    selected="{Boolean}false"/>
+            </options>
+        </select-standard>
+        <select-required
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/selectfield"
+            label="Select (Required)"
+            name="selectRequired"
+            required="{Boolean}true">
+            <options jcr:primaryType="nt:unstructured">
+                <option-x
+                    jcr:primaryType="nt:unstructured"
+                    text="Option X"
+                    value="x"
+                    selected="{Boolean}true"/>
+                <option-y
+                    jcr:primaryType="nt:unstructured"
+                    text="Option Y"
+                    value="y"
+                    selected="{Boolean}false"/>
+            </options>
+        </select-required>
+
+        <pathfield-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/pathfield"
+            label="Path (Asset)"
+            name="assetPath"
+            required="{Boolean}false"/>
+        <pathfield-page
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/pathfield"
+            label="Path (Page, Required)"
+            name="pagePath"
+            required="{Boolean}true"/>
+
+        <number-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/numberfield"
+            label="Number"
+            name="numberValue"
+            required="{Boolean}false"/>
+        <number-required
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/numberfield"
+            label="Number (Required)"
+            name="numberRequired"
+            required="{Boolean}true"/>
+
+        <date-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/datefield"
+            label="Date"
+            name="dateValue"
+            required="{Boolean}false"/>
+
+        <datetime-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/datetimefield"
+            label="Date + Time"
+            name="datetimeValue"
+            required="{Boolean}false"/>
+
+        <hidden-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/hiddenfield"
+            label="Hidden"
+            name="hiddenValue"
+            required="{Boolean}false"/>
+
+        <toggle-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/togglefield"
+            label="Toggle"
+            name="toggleValue"
+            required="{Boolean}false"/>
+        <toggle-disabled
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/togglefield"
+            label="Toggle (Disabled)"
+            name="toggleDisabled"
+            required="{Boolean}false"
+            disabled="{Boolean}true"/>
+
+        <radiogroup-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/radiogroup"
+            label="Radio Group"
+            name="radioValue"
+            required="{Boolean}false">
+            <options jcr:primaryType="nt:unstructured">
+                <radio-a
+                    jcr:primaryType="nt:unstructured"
+                    text="Radio A"
+                    value="a"
+                    selected="{Boolean}true"/>
+                <radio-b
+                    jcr:primaryType="nt:unstructured"
+                    text="Radio B"
+                    value="b"
+                    selected="{Boolean}false"/>
+                <radio-c
+                    jcr:primaryType="nt:unstructured"
+                    text="Radio C"
+                    value="c"
+                    selected="{Boolean}false"/>
+            </options>
+        </radiogroup-standard>
+        <radiogroup-required
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/radiogroup"
+            label="Radio Group (Required)"
+            name="radioRequired"
+            required="{Boolean}true">
+            <options jcr:primaryType="nt:unstructured">
+                <radio-x
+                    jcr:primaryType="nt:unstructured"
+                    text="Radio X"
+                    value="x"
+                    selected="{Boolean}false"/>
+                <radio-y
+                    jcr:primaryType="nt:unstructured"
+                    text="Radio Y"
+                    value="y"
+                    selected="{Boolean}false"/>
+            </options>
+        </radiogroup-required>
+
+        <tagfield-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/tagfield"
+            label="Tag Field"
+            name="tagValue"
+            required="{Boolean}false"/>
+
+        <richtext-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/richtext"
+            label="Rich Text"
+            name="richTextValue"
+            required="{Boolean}false"/>
+
+    </content>
+</jcr:root>

--- a/basic-components-sample/src/content/jcr_root/content/sites/basic-components-sample/components/dialog-field-sample/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/content/sites/basic-components-sample/components/dialog-field-sample/.content.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:kes="http://kestros.io/kes/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+        jcr:primaryType="kes:Page">
+    <jcr:content
+        jcr:description="Debug component for verifying all dialog field types."
+        jcr:primaryType="nt:unstructured"
+        jcr:title="Dialog Field Sample"
+        kes:template="/libs/kestros/commons/base-page-template"
+        sling:resourceType="kestros/commons/components/kestros-base-page">
+        <header
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="kestros/commons/components/inherited-content-area"/>
+        <main
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="kestros/commons/components/content-area">
+            <section
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="/libs/kestros/commons/components/structure/section">
+                <inherited-content-area
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/inherited-content-area"/>
+                <container
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/structure/container"
+                        elementType="main">
+                    <grid
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/grid">
+                        <column-1
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="kestros/commons/components/content-area">
+                            <inherited-content-area
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/inherited-content-area"/>
+                        </column-1>
+                        <column-2
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="kestros/commons/components/content-area">
+                            <heading
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                    level="h4"
+                                    text="Dialog Field Debugger"/>
+                            <dialog-field-sample
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/samples/components/content/dialog-field-sample"
+                                    textRequired="Sample text value"
+                                    textOptional="Optional value"
+                                    selectValue="a"
+                                    radioValue="a"
+                                    toggleValue="{Boolean}true"
+                                    numberValue="{Long}42"/>
+                        </column-2>
+                        <column-3
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="kestros/commons/components/content-area"/>
+                    </grid>
+                </container>
+            </section>
+        </main>
+        <footer
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="kestros/commons/components/inherited-content-area"/>
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION
## Summary
- Adds `dialog-field-sample` component under `/apps/kestros/samples/components/content/dialog-field-sample`
- Edit dialog covers all 13 currently-supported KDF field types: textfield, textarea, checkbox, selectfield, pathfield, numberfield, datefield, datetimefield, hiddenfield, togglefield, radiogroup, tagfield, richtext
- Includes required/optional/disabled variants where applicable
- Common view renders authored values as a debug table
- Adds sample page at `/content/sites/basic-components-sample/components/dialog-field-sample`
- Multifield tracked separately in TASK-302

## Test plan
- [ ] Open edit dialog on the dialog-field-sample page in the site editor
- [ ] Verify all 13 field types render with correct labels and variants
- [ ] Verify required fields show validation, disabled fields are non-interactive
- [ ] Save values and confirm they appear in the debug view on the page