### PR TITLE
[basic-components-sample] Add toggle field onLabel/offLabel to sample

### DIFF
--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
@@ -148,6 +148,8 @@
             sling:resourceType="kestros/cms2/fields/general/togglefield"
             label="Toggle"
             name="toggleValue"
+            onLabel="On"
+            offLabel="Off"
             required="{Boolean}false"/>
         <toggle-disabled
             jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
Task: TASK-030

Adds onLabel and offLabel optional properties to the toggle-standard dialog field sample entry, demonstrating the full toggle field API. The toggle-standard and toggle-disabled entries were added in PR #34 (TASK-295). This PR enhances the sample with the optional custom state labels supported by the ToggleFieldMolecule interface.

Companion PRs:
- kestros-site-administration PR #50 (merged)
- kestros-design-framework PR #59 (merged)