### PR TITLE
Configure hidden field with static value in dialog-field-sample

### DIFF
--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
@@ -139,9 +139,8 @@
         <hidden-standard
             jcr:primaryType="nt:unstructured"
             sling:resourceType="kestros/cms2/fields/general/hiddenfield"
-            label="Hidden"
             name="hiddenValue"
-            required="{Boolean}false"/>
+            value="default-hidden-value"/>
 
         <toggle-standard
             jcr:primaryType="nt:unstructured"

--- a/basic-components-sample/src/content/jcr_root/content/sites/basic-components-sample/components/dialog-field-sample/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/content/sites/basic-components-sample/components/dialog-field-sample/.content.xml
@@ -49,7 +49,8 @@
                                     selectValue="a"
                                     radioValue="a"
                                     toggleValue="{Boolean}true"
-                                    numberValue="{Long}42"/>
+                                    numberValue="{Long}42"
+                                    hiddenValue="default-hidden-value"/>
                         </column-2>
                         <column-3
                                 jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
Sets a static value on the hidden field in the dialog-field-sample edit dialog and adds hiddenValue to the sample content instance.