### PR TITLE
feat: TASK-033 add file upload to dialog-field-sample

### DIFF
--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
@@ -21,5 +21,7 @@
     <dt>radioRequired</dt>      <dd>${properties.radioRequired @ context='text'}</dd>
     <dt>tagValue</dt>           <dd>${properties.tagValue @ context='text'}</dd>
     <dt>richTextValue</dt>      <dd>${properties.richTextValue @ context='html'}</dd>
+    <dt>fileUploadValue</dt>    <dd>${properties.fileUploadValue @ context='text'}</dd>
+    <dt>fileUploadRequired</dt> <dd>${properties.fileUploadRequired @ context='text'}</dd>
     <dt>multifieldItems</dt>    <dd>${properties.multifieldItems @ context='text'}</dd>
 </dl>

--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
@@ -216,5 +216,21 @@
             name="richTextValue"
             required="{Boolean}false"/>
 
+        <fileupload-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/filefield"
+            label="File Upload"
+            name="fileUploadValue"
+            uploadUrl="/bin/kestros/assets/upload"
+            required="{Boolean}false"/>
+        <fileupload-required
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/filefield"
+            label="File Upload (Required)"
+            name="fileUploadRequired"
+            uploadUrl="/bin/kestros/assets/upload"
+            accept="image/*,.pdf"
+            required="{Boolean}true"/>
+
     </content>
 </jcr:root>


### PR DESCRIPTION
## Summary
- Add `fileupload-standard` and `fileupload-required` field entries to the dialog-field-sample component dialog
- Add output rendering for `fileUploadValue` and `fileUploadRequired` in the component view template

## Companion PR
Requires [kestros-site-administration PR #62](https://github.com/kestros/kestros-site-administration/pull/62) to be deployed first (provides the `kestros/cms2/fields/general/filefield` resource type).

## Test Plan
- [ ] Deploy the site-administration application2 bundle first
- [ ] Install the basic-components-sample content package
- [ ] Navigate to the dialog-field-sample page
- [ ] Verify file upload fields appear in the edit dialog
- [ ] Verify uploaded file paths render in the component output