### PR TITLE
feat: add integer-only number field to dialog-field-sample (TASK-028)

### DIFF
--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
@@ -12,6 +12,7 @@
     <dt>pagePath</dt>           <dd>${properties.pagePath @ context='text'}</dd>
     <dt>numberValue</dt>        <dd>${properties.numberValue @ context='text'}</dd>
     <dt>numberRequired</dt>     <dd>${properties.numberRequired @ context='text'}</dd>
+    <dt>numberInteger</dt>      <dd>${properties.numberInteger @ context='text'}</dd>
     <dt>dateValue</dt>          <dd>${properties.dateValue @ context='text'}</dd>
     <dt>datetimeValue</dt>      <dd>${properties.datetimeValue @ context='text'}</dd>
     <dt>hiddenValue</dt>        <dd>${properties.hiddenValue @ context='text'}</dd>

--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
@@ -121,6 +121,14 @@
             label="Number (Required)"
             name="numberRequired"
             required="{Boolean}true"/>
+        <number-integer
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/numberfield"
+            label="Number (Integer Only)"
+            name="numberInteger"
+            integerOnly="{Boolean}true"
+            min="{Float}0"
+            max="{Float}100"/>
 
         <date-standard
             jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
## Summary
- Adds a `number-integer` field to the dialog-field-sample dialog with `integerOnly=true`, `min=0`, `max=100`
- Adds `numberInteger` output rendering in the component's content.html view

## Context
Per Danny's note: each dialog field task must (1) add a use of the field type to dialog-field-sample's dialog and (2) add output rendering for that field's value in the component's view.

## Dependencies
- kestros-design-framework PR #120 (interface change)
- kestros-site-administration PR #67 (implementation)

## Test plan
- [ ] dialog-field-sample dialog includes "Number (Integer Only)" field
- [ ] Field enforces integer-only input (step=1, pattern=[0-9]*)
- [ ] numberInteger value renders in component output