### PR TITLE
Move rat plugin to strict profile

### DIFF
--- a/explore/app/pom.xml
+++ b/explore/app/pom.xml
@@ -49,37 +49,6 @@
 
     <plugins>
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <version>0.13</version>
-        <configuration>
-          <excludes>
-            <!-- don't check anything in target -->
-            <exclude>target/*</exclude>
-            <!-- Fixing issues with deleted modules -->
-            <exclude>**/target/*</exclude>
-            <exclude>**/target/**/*</exclude>
-            <exclude>**/*.json</exclude>
-            <exclude>node/**/*</exclude>
-            <exclude>node_modules/**/*</exclude>
-            <exclude>**/README.md</exclude>
-            <exclude>package.json</exclude>
-            <exclude>package-lock.json</exclude>
-            <exclude>*-maven-settings.xml</exclude>
-            <exclude>src/main/resources/content/ROOT.json</exclude>
-            <exclude>src/main/resources/startup/favicon.svg</exclude>
-          </excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
@@ -99,5 +68,47 @@
       </plugin>
     </plugins>
   </build>
+
+
+    <profiles>
+        <profile>
+            <id>strict</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <version>0.13</version>
+                        <configuration>
+                            <excludes>
+                                <!-- don't check anything in target -->
+                                <exclude>target/*</exclude>
+                                <!-- Fixing issues with deleted modules -->
+                                <exclude>**/target/*</exclude>
+                                <exclude>**/target/**/*</exclude>
+                                <exclude>**/*.json</exclude>
+                                <exclude>node/**/*</exclude>
+                                <exclude>node_modules/**/*</exclude>
+                                <exclude>**/README.md</exclude>
+                                <exclude>package.json</exclude>
+                                <exclude>package-lock.json</exclude>
+                                <exclude>*-maven-settings.xml</exclude>
+                                <exclude>src/main/resources/content/ROOT.json</exclude>
+                                <exclude>src/main/resources/startup/favicon.svg</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/explore/content/pom.xml
+++ b/explore/content/pom.xml
@@ -49,37 +49,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <version>0.13</version>
-                <configuration>
-                    <excludes>
-                        <!-- don't check anything in target -->
-                        <exclude>target/*</exclude>
-                        <!-- Fixing issues with deleted modules -->
-                        <exclude>**/target/*</exclude>
-                        <exclude>**/target/**/*</exclude>
-                        <exclude>**/*.json</exclude>
-                        <exclude>node/**/*</exclude>
-                        <exclude>node_modules/**/*</exclude>
-                        <exclude>**/README.md</exclude>
-                        <exclude>package.json</exclude>
-                        <exclude>package-lock.json</exclude>
-                        <exclude>*-maven-settings.xml</exclude>
-                        <exclude>src/main/resources/content/ROOT.json</exclude>
-                        <exclude>src/main/resources/startup/favicon.svg</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
@@ -101,5 +70,47 @@
             </plugin>
         </plugins>
     </build>
+
+
+    <profiles>
+        <profile>
+            <id>strict</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <version>0.13</version>
+                        <configuration>
+                            <excludes>
+                                <!-- don't check anything in target -->
+                                <exclude>target/*</exclude>
+                                <!-- Fixing issues with deleted modules -->
+                                <exclude>**/target/*</exclude>
+                                <exclude>**/target/**/*</exclude>
+                                <exclude>**/*.json</exclude>
+                                <exclude>node/**/*</exclude>
+                                <exclude>node_modules/**/*</exclude>
+                                <exclude>**/README.md</exclude>
+                                <exclude>package.json</exclude>
+                                <exclude>package-lock.json</exclude>
+                                <exclude>*-maven-settings.xml</exclude>
+                                <exclude>src/main/resources/content/ROOT.json</exclude>
+                                <exclude>src/main/resources/startup/favicon.svg</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/lorem-ipsum-site/content/pom.xml
+++ b/lorem-ipsum-site/content/pom.xml
@@ -47,37 +47,6 @@
 
     <plugins>
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <version>0.13</version>
-        <configuration>
-          <excludes>
-            <!-- don't check anything in target -->
-            <exclude>target/*</exclude>
-            <!-- Fixing issues with deleted modules -->
-            <exclude>**/target/*</exclude>
-            <exclude>**/target/**/*</exclude>
-            <exclude>**/*.json</exclude>
-            <exclude>node/**/*</exclude>
-            <exclude>node_modules/**/*</exclude>
-            <exclude>**/README.md</exclude>
-            <exclude>package.json</exclude>
-            <exclude>package-lock.json</exclude>
-            <exclude>*-maven-settings.xml</exclude>
-            <exclude>src/main/resources/content/ROOT.json</exclude>
-            <exclude>src/main/resources/startup/favicon.svg</exclude>
-          </excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
@@ -91,5 +60,47 @@
       </plugin>
     </plugins>
   </build>
+
+
+    <profiles>
+        <profile>
+            <id>strict</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <version>0.13</version>
+                        <configuration>
+                            <excludes>
+                                <!-- don't check anything in target -->
+                                <exclude>target/*</exclude>
+                                <!-- Fixing issues with deleted modules -->
+                                <exclude>**/target/*</exclude>
+                                <exclude>**/target/**/*</exclude>
+                                <exclude>**/*.json</exclude>
+                                <exclude>node/**/*</exclude>
+                                <exclude>node_modules/**/*</exclude>
+                                <exclude>**/README.md</exclude>
+                                <exclude>package.json</exclude>
+                                <exclude>package-lock.json</exclude>
+                                <exclude>*-maven-settings.xml</exclude>
+                                <exclude>src/main/resources/content/ROOT.json</exclude>
+                                <exclude>src/main/resources/startup/favicon.svg</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/lorem-ipsum-site/frontend/pom.xml
+++ b/lorem-ipsum-site/frontend/pom.xml
@@ -47,37 +47,6 @@
 
     <plugins>
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <version>0.13</version>
-        <configuration>
-          <excludes>
-            <!-- don't check anything in target -->
-            <exclude>target/*</exclude>
-            <!-- Fixing issues with deleted modules -->
-            <exclude>**/target/*</exclude>
-            <exclude>**/target/**/*</exclude>
-            <exclude>**/*.json</exclude>
-            <exclude>node/**/*</exclude>
-            <exclude>node_modules/**/*</exclude>
-            <exclude>**/README.md</exclude>
-            <exclude>package.json</exclude>
-            <exclude>package-lock.json</exclude>
-            <exclude>*-maven-settings.xml</exclude>
-            <exclude>src/main/resources/content/ROOT.json</exclude>
-            <exclude>src/main/resources/startup/favicon.svg</exclude>
-          </excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
@@ -93,5 +62,47 @@
       </plugin>
     </plugins>
   </build>
+
+
+    <profiles>
+        <profile>
+            <id>strict</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <version>0.13</version>
+                        <configuration>
+                            <excludes>
+                                <!-- don't check anything in target -->
+                                <exclude>target/*</exclude>
+                                <!-- Fixing issues with deleted modules -->
+                                <exclude>**/target/*</exclude>
+                                <exclude>**/target/**/*</exclude>
+                                <exclude>**/*.json</exclude>
+                                <exclude>node/**/*</exclude>
+                                <exclude>node_modules/**/*</exclude>
+                                <exclude>**/README.md</exclude>
+                                <exclude>package.json</exclude>
+                                <exclude>package-lock.json</exclude>
+                                <exclude>*-maven-settings.xml</exclude>
+                                <exclude>src/main/resources/content/ROOT.json</exclude>
+                                <exclude>src/main/resources/startup/favicon.svg</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
Move apache-rat-plugin behind the strict Maven profile so it only runs with -P strict, not on normal builds.