### PR TITLE
Use shared Bloom framework for launchpad-io site

### DIFF
--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
@@ -148,8 +148,6 @@
             sling:resourceType="kestros/cms2/fields/general/togglefield"
             label="Toggle"
             name="toggleValue"
-            onLabel="On"
-            offLabel="Off"
             required="{Boolean}false"/>
         <toggle-disabled
             jcr:primaryType="nt:unstructured"

--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
@@ -148,6 +148,8 @@
             sling:resourceType="kestros/cms2/fields/general/togglefield"
             label="Toggle"
             name="toggleValue"
+            onLabel="On"
+            offLabel="Off"
             required="{Boolean}false"/>
         <toggle-disabled
             jcr:primaryType="nt:unstructured"

--- a/launchpad-io/content/pom.xml
+++ b/launchpad-io/content/pom.xml
@@ -49,33 +49,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <version>0.13</version>
-                <configuration>
-                    <excludes>
-                        <exclude>target/*</exclude>
-                        <exclude>**/target/*</exclude>
-                        <exclude>**/target/**/*</exclude>
-                        <exclude>**/*.json</exclude>
-                        <exclude>node/**/*</exclude>
-                        <exclude>node_modules/**/*</exclude>
-                        <exclude>**/README.md</exclude>
-                        <exclude>package.json</exclude>
-                        <exclude>package-lock.json</exclude>
-                        <exclude>*-maven-settings.xml</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>

--- a/launchpad-io/content/pom.xml
+++ b/launchpad-io/content/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~      Copyright (C) 2020  Kestros, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, either version 3 of the License, or
+  ~     (at your option) any later version.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kestros.cms.sample-sites</groupId>
+        <artifactId>launchpad-io-site</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.kestros.cms.sample-sites</groupId>
+    <artifactId>launchpad-io-site-content</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <name>Launchpad.io Site - Content</name>
+    <description>Content bundle for the Launchpad.io sample site using the shared Bloom (Bulma) framework</description>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <bundleCategory>kestros</bundleCategory>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <version>0.13</version>
+                <configuration>
+                    <excludes>
+                        <exclude>target/*</exclude>
+                        <exclude>**/target/*</exclude>
+                        <exclude>**/target/**/*</exclude>
+                        <exclude>**/*.json</exclude>
+                        <exclude>node/**/*</exclude>
+                        <exclude>node_modules/**/*</exclude>
+                        <exclude>**/README.md</exclude>
+                        <exclude>package.json</exclude>
+                        <exclude>package-lock.json</exclude>
+                        <exclude>*-maven-settings.xml</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Sling-Initial-Content>
+                            /content/sites/launchpad-io.json;overwrite:=true;path:=/content/sites/launchpad-io,
+                            /content/sites/launchpad-io/features.json;overwrite:=true;path:=/content/sites/launchpad-io/features,
+                            /content/sites/launchpad-io/pricing.json;overwrite:=true;path:=/content/sites/launchpad-io/pricing,
+                            /content/sites/launchpad-io/about.json;overwrite:=true;path:=/content/sites/launchpad-io/about
+                        </Sling-Initial-Content>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/launchpad-io/content/src/main/resources/content/sites/launchpad-io.json
+++ b/launchpad-io/content/src/main/resources/content/sites/launchpad-io.json
@@ -1,0 +1,191 @@
+{
+  "jcr:primaryType": "kes:Site",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "kes:theme": "/etc/ui-frameworks/bloom/versions/0.0.1/themes/default",
+    "jcr:title": "Launchpad.io",
+    "publicationStrategy": "kestros-single-instance",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "hero-container": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "container": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/container",
+          "top-navigation": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/structure/top-navigation"
+          },
+          "heading": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/heading",
+            "level": "h1",
+            "text": "Launchpad.io"
+          },
+          "text": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/text",
+            "text": "Launch your next project with confidence. A modern platform for building, deploying, and scaling web applications."
+          },
+          "cta-button": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/button",
+            "text": "Get Started",
+            "link": "/content/sites/launchpad-io/features.html"
+          },
+          "cta-button-2": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/button",
+            "text": "View Pricing",
+            "link": "/content/sites/launchpad-io/pricing.html"
+          }
+        }
+      },
+      "features-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "container": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/container",
+          "heading": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/heading",
+            "level": "h2",
+            "text": "Why Launchpad?"
+          },
+          "grid": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/structure/grid",
+            "columns": 3,
+            "column-1": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content-area",
+              "card": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/card",
+                "jcr:title": "Fast Deployment",
+                "richtext": {
+                  "jcr:primaryType": "nt:unstructured",
+                  "sling:resourceType": "kestros/commons/components/content/richtext",
+                  "text": "<p>Deploy your application in seconds with our streamlined CI/CD pipeline. Zero downtime deployments are standard.</p>"
+                }
+              }
+            },
+            "column-2": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content-area",
+              "card": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/card",
+                "jcr:title": "Auto-Scaling",
+                "richtext": {
+                  "jcr:primaryType": "nt:unstructured",
+                  "sling:resourceType": "kestros/commons/components/content/richtext",
+                  "text": "<p>Automatically scale your infrastructure based on traffic. Pay only for what you use with intelligent resource management.</p>"
+                }
+              }
+            },
+            "column-3": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content-area",
+              "card": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/card",
+                "jcr:title": "Built-in Security",
+                "richtext": {
+                  "jcr:primaryType": "nt:unstructured",
+                  "sling:resourceType": "kestros/commons/components/content/richtext",
+                  "text": "<p>Enterprise-grade security out of the box. SSL certificates, DDoS protection, and vulnerability scanning included.</p>"
+                }
+              }
+            }
+          }
+        }
+      },
+      "cta-section": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "container": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/container",
+          "heading": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/heading",
+            "level": "h2",
+            "text": "Ready to Launch?"
+          },
+          "text": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/text",
+            "text": "Join thousands of developers who trust Launchpad.io for their production workloads."
+          },
+          "button": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/button",
+            "text": "Start Free Trial",
+            "link": "/content/sites/launchpad-io/pricing.html"
+          }
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true,
+      "container": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "grid": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/grid",
+          "columns": 3,
+          "column-1": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "heading": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/heading",
+              "level": "h4",
+              "text": "Launchpad.io"
+            },
+            "text": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/text",
+              "text": "Modern infrastructure for modern applications."
+            }
+          },
+          "column-2": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "heading": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/heading",
+              "level": "h4",
+              "text": "Links"
+            },
+            "page-list": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/page-list"
+            }
+          },
+          "column-3": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "richtext": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/richtext",
+              "text": "<p>Built with Kestros CMS and Bulma CSS framework.</p>"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/launchpad-io/content/src/main/resources/content/sites/launchpad-io/about.json
+++ b/launchpad-io/content/src/main/resources/content/sites/launchpad-io/about.json
@@ -1,0 +1,108 @@
+{
+  "jcr:primaryType": "kes:Page",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "jcr:title": "About",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "container": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "top-navigation": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/top-navigation"
+        },
+        "heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h1",
+          "text": "About Launchpad.io"
+        }
+      },
+      "container-1": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "container": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/container",
+          "grid": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/structure/grid",
+            "columns": 2,
+            "column-1": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content-area",
+              "heading": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/heading",
+                "level": "h2",
+                "text": "Our Mission"
+              },
+              "text": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/text",
+                "text": "We believe that deploying and scaling web applications should be simple and accessible to everyone. Launchpad.io was founded to remove the complexity from infrastructure management so developers can focus on building great products."
+              },
+              "text-1": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/text",
+                "text": "Our platform handles everything from build pipelines to production monitoring, letting teams ship faster with confidence."
+              }
+            },
+            "column-2": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content-area",
+              "heading": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/heading",
+                "level": "h2",
+                "text": "By the Numbers"
+              },
+              "richtext": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/richtext",
+                "text": "<ul><li><strong>10,000+</strong> applications deployed</li><li><strong>99.99%</strong> uptime SLA</li><li><strong>50+</strong> edge locations worldwide</li><li><strong>2,500+</strong> teams trust Launchpad</li></ul>"
+              }
+            }
+          }
+        }
+      },
+      "container-2": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "container": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/container",
+          "heading": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/heading",
+            "level": "h2",
+            "text": "Contact Us"
+          },
+          "text": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/text",
+            "text": "Have questions? Reach out to our team and we will get back to you within 24 hours."
+          },
+          "button": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content/button",
+            "text": "Get in Touch",
+            "link": "#"
+          }
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true
+    }
+  }
+}

--- a/launchpad-io/content/src/main/resources/content/sites/launchpad-io/features.json
+++ b/launchpad-io/content/src/main/resources/content/sites/launchpad-io/features.json
@@ -1,0 +1,126 @@
+{
+  "jcr:primaryType": "kes:Page",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "jcr:title": "Features",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "container": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "top-navigation": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/top-navigation"
+        },
+        "heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h1",
+          "text": "Features"
+        },
+        "text": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Everything you need to build and deploy modern web applications."
+        }
+      },
+      "container-1": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "container": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/container",
+          "grid": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/structure/grid",
+            "columns": 2,
+            "column-1": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content-area",
+              "heading": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/heading",
+                "level": "h3",
+                "text": "Continuous Deployment"
+              },
+              "text": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/text",
+                "text": "Push to your main branch and your changes are live in seconds. Automatic rollback if health checks fail. Branch previews for every pull request."
+              }
+            },
+            "column-2": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content-area",
+              "heading": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/heading",
+                "level": "h3",
+                "text": "Global CDN"
+              },
+              "text": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/text",
+                "text": "Your content is served from edge locations around the world. Sub-50ms response times for static assets. Automatic cache invalidation on deploy."
+              }
+            }
+          }
+        }
+      },
+      "container-2": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "container": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/container",
+          "grid": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/structure/grid",
+            "columns": 2,
+            "column-1": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content-area",
+              "heading": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/heading",
+                "level": "h3",
+                "text": "Database Management"
+              },
+              "text": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/text",
+                "text": "Managed PostgreSQL, MySQL, and Redis instances with automatic backups. Point-in-time recovery and read replicas available."
+              }
+            },
+            "column-2": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content-area",
+              "heading": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/heading",
+                "level": "h3",
+                "text": "Team Collaboration"
+              },
+              "text": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/text",
+                "text": "Invite your team with fine-grained access controls. Activity logs and audit trails for every deployment. Integrations with Slack and GitHub."
+              }
+            }
+          }
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true
+    }
+  }
+}

--- a/launchpad-io/content/src/main/resources/content/sites/launchpad-io/pricing.json
+++ b/launchpad-io/content/src/main/resources/content/sites/launchpad-io/pricing.json
@@ -1,0 +1,115 @@
+{
+  "jcr:primaryType": "kes:Page",
+  "jcr:content": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/commons/components/kestros-base-page",
+    "jcr:title": "Pricing",
+    "header": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area"
+    },
+    "main": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/content-area",
+      "container": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "top-navigation": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/top-navigation"
+        },
+        "heading": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/heading",
+          "level": "h1",
+          "text": "Pricing"
+        },
+        "text": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/content/text",
+          "text": "Simple, transparent pricing for teams of all sizes."
+        }
+      },
+      "container-1": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/commons/components/structure/container",
+        "grid": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "kestros/commons/components/structure/grid",
+          "columns": 3,
+          "column-1": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "card": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/card",
+              "jcr:title": "Starter",
+              "callToActionText": "Get Started",
+              "link": "#",
+              "heading": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/heading",
+                "level": "h3",
+                "text": "Free"
+              },
+              "richtext": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/richtext",
+                "text": "<ul><li>1 Project</li><li>100 GB Bandwidth</li><li>SSL Certificate</li><li>Community Support</li></ul>"
+              }
+            }
+          },
+          "column-2": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "card": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/card",
+              "jcr:title": "Professional",
+              "callToActionText": "Start Trial",
+              "link": "#",
+              "heading": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/heading",
+                "level": "h3",
+                "text": "$29/mo"
+              },
+              "richtext": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/richtext",
+                "text": "<ul><li>10 Projects</li><li>1 TB Bandwidth</li><li>Custom Domains</li><li>Priority Support</li><li>Team Collaboration</li></ul>"
+              }
+            }
+          },
+          "column-3": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "kestros/commons/components/content-area",
+            "card": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "kestros/commons/components/content/card",
+              "jcr:title": "Enterprise",
+              "callToActionText": "Contact Sales",
+              "link": "#",
+              "heading": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/heading",
+                "level": "h3",
+                "text": "Custom"
+              },
+              "richtext": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "kestros/commons/components/content/richtext",
+                "text": "<ul><li>Unlimited Projects</li><li>Unlimited Bandwidth</li><li>SLA Guarantee</li><li>Dedicated Support</li><li>Custom Integrations</li></ul>"
+              }
+            }
+          }
+        }
+      }
+    },
+    "footer": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "kestros/commons/components/inherited-content-area",
+      "reset": true
+    }
+  }
+}

--- a/launchpad-io/pom.xml
+++ b/launchpad-io/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~      Copyright (C) 2020  Kestros, Inc.
   ~
@@ -23,19 +22,19 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.kestros.commons</groupId>
-    <artifactId>kestros-parent</artifactId>
-    <version>0.3.3</version>
+    <groupId>io.kestros.cms</groupId>
+    <artifactId>kestros-site-parent</artifactId>
+    <version>0.1.2-SNAPSHOT</version>
     <relativePath/>
   </parent>
 
-  <groupId>io.kestros.cms</groupId>
-  <artifactId>kestros-sample-sites</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
-
-  <name>Kestros Sample Sites</name>
-  <description>Sample sites and demo applications for the Kestros CMS platform</description>
+  <groupId>io.kestros.cms.sample-sites</groupId>
+  <artifactId>launchpad-io-site</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
+
+  <name>Launchpad.io Site</name>
+  <description>Launchpad.io Sample Site - uses the shared Bloom (Bulma) UI framework</description>
 
   <licenses>
     <license>
@@ -52,13 +51,7 @@
   </scm>
 
   <modules>
-<!--    <module>lorem-ipsum-site</module>-->
-    <module>explore</module>
-<!--    <module>resolve-2021</module>-->
-    <module>basic-components-sample</module>
-    <module>launchpad-io</module>
+    <module>content</module>
   </modules>
 
-  <dependencyManagement>
-  </dependencyManagement>
 </project>


### PR DESCRIPTION
Replaces custom launchpad-io-framework with the shared Bloom framework from kestros-ui-frameworks. Content-only bundle, no app module.