### PR TITLE
feat: Playwright E2E testing infrastructure (TASK-296)

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+.auth/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,92 @@
+# Kestros CMS E2E Tests
+
+Playwright-based end-to-end tests for the Kestros CMS dev instance.
+
+## Prerequisites
+
+- Node.js 18+
+- Access to the Kestros CMS dev instance (default: `http://192.168.86.216:8000`)
+
+## Setup
+
+```bash
+cd e2e
+npm install
+npx playwright install
+```
+
+## Configuration
+
+Tests target the Kestros CMS dev instance. Configure via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `KESTROS_CMS_URL` | `http://192.168.86.216:8000` | Base URL of the CMS instance |
+| `KESTROS_CMS_USER` | `admin` | CMS admin username |
+| `KESTROS_CMS_PASSWORD` | *(required)* | CMS admin password |
+
+## Running Tests
+
+```bash
+# Set the CMS password (required)
+export KESTROS_CMS_PASSWORD=your-password
+
+# Run all tests
+npm test
+
+# Run smoke tests only
+npm run test:smoke
+
+# Run tests in headed mode (see the browser)
+npm run test:headed
+
+# Run tests with Playwright UI
+npm run test:ui
+
+# View the HTML report
+npm run report
+```
+
+## Test Structure
+
+```
+e2e/
+  playwright.config.ts    # Playwright configuration
+  tests/
+    global-setup.ts       # Authenticates as admin, saves session state
+    global-teardown.ts    # Cleans up test data (placeholder)
+    smoke.spec.ts         # Smoke tests — instance reachability & auth
+  .auth/                  # Saved auth state (gitignored)
+  test-results/           # Test output (gitignored)
+  playwright-report/      # HTML report (gitignored)
+```
+
+## How It Works
+
+1. **Authentication**: The `global-setup.ts` project logs in via the Sling form login endpoint (`/system/sling/form/login`) and saves the authenticated browser state to `.auth/admin.json`. All test projects reuse this state so they don't need to log in individually.
+
+2. **Test Data**: Tests that create content use the Sling POST servlet directly via Playwright's `request` API. Content is created under unique paths and cleaned up in each test's teardown.
+
+3. **Cross-Browser**: Tests run in Chromium, Firefox, and WebKit by default. Use `--project=chromium` to run in a single browser.
+
+## CI Integration
+
+For Jenkins or other CI systems:
+
+```bash
+# Install dependencies
+npm ci
+npx playwright install --with-deps
+
+# Run tests with JUnit output
+KESTROS_CMS_PASSWORD=$CMS_PASSWORD npx playwright test --reporter=junit
+```
+
+Test results are written to `test-results/results.xml` in JUnit format when `CI=true` is set.
+
+## Adding New Tests
+
+1. Create a new `.spec.ts` file in `tests/`
+2. Tests automatically inherit the authenticated session from `global-setup.ts`
+3. Use `test.describe` groups with tags (e.g., `@smoke`, `@dialogs`) for selective runs
+4. Clean up any JCR nodes created during tests in an `afterAll` hook

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "kestros-e2e-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kestros-e2e-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "kestros-e2e-tests",
+  "version": "1.0.0",
+  "description": "Playwright E2E tests for Kestros CMS",
+  "private": true,
+  "scripts": {
+    "test": "npx playwright test",
+    "test:headed": "npx playwright test --headed",
+    "test:ui": "npx playwright test --ui",
+    "test:smoke": "npx playwright test --grep @smoke",
+    "report": "npx playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,92 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for Kestros CMS E2E tests.
+ *
+ * Tests run against the Kestros CMS dev instance at port 8000.
+ * Auth credentials are read from environment variables.
+ *
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests sequentially in CI, parallel locally */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Limit parallel workers on CI */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter configuration */
+  reporter: process.env.CI
+    ? [['junit', { outputFile: 'test-results/results.xml' }], ['html', { open: 'never' }]]
+    : [['html', { open: 'on-failure' }]],
+  /* Shared settings for all the projects below */
+  use: {
+    /* Base URL for the Kestros CMS dev instance */
+    baseURL: process.env.KESTROS_CMS_URL || 'http://192.168.86.216:8000',
+
+    /* HTTP credentials for Sling Basic Auth */
+    httpCredentials: {
+      username: process.env.KESTROS_CMS_USER || 'admin',
+      password: process.env.KESTROS_CMS_PASSWORD || '',
+    },
+
+    /* Collect trace on first retry */
+    trace: 'on-first-retry',
+
+    /* Screenshot on failure */
+    screenshot: 'only-on-failure',
+
+    /* Video on failure */
+    video: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    /* Setup project — authenticates and saves state */
+    {
+      name: 'setup',
+      testMatch: /global-setup\.ts/,
+      teardown: 'teardown',
+    },
+    {
+      name: 'teardown',
+      testMatch: /global-teardown\.ts/,
+    },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        /* Use authenticated state from setup */
+        storageState: '.auth/admin.json',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: '.auth/admin.json',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: '.auth/admin.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+
+  /* Timeout for each test */
+  timeout: 30_000,
+
+  /* Timeout for each expect() assertion */
+  expect: {
+    timeout: 10_000,
+  },
+});

--- a/e2e/tests/global-setup.ts
+++ b/e2e/tests/global-setup.ts
@@ -1,0 +1,42 @@
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = '.auth/admin.json';
+
+/**
+ * Global setup — authenticates as admin and saves browser state.
+ *
+ * Sling supports both form-based login and HTTP Basic Auth.
+ * We use the Sling form login endpoint to get a session cookie,
+ * then save the authenticated state for all test projects to reuse.
+ */
+setup('authenticate as admin', async ({ page, baseURL }) => {
+  const user = process.env.KESTROS_CMS_USER || 'admin';
+  const pass = process.env.KESTROS_CMS_PASSWORD || '';
+
+  if (!pass) {
+    throw new Error(
+      'KESTROS_CMS_PASSWORD environment variable is required. ' +
+      'Set it to the admin password for the Kestros CMS dev instance.'
+    );
+  }
+
+  // Login via Sling form login endpoint
+  await page.goto(`${baseURL}/system/sling/form/login`);
+
+  // Fill in the login form
+  await page.fill('input[name="j_username"]', user);
+  await page.fill('input[name="j_password"]', pass);
+  await page.click('button[type="submit"], input[type="submit"]');
+
+  // Wait for redirect after login — Sling redirects to the resource or root
+  await page.waitForURL((url) => !url.pathname.includes('/login'), {
+    timeout: 15_000,
+  });
+
+  // Verify we are authenticated by checking we can access the system console
+  const response = await page.goto(`${baseURL}/system/console/bundles`);
+  expect(response?.status()).toBeLessThan(400);
+
+  // Save authenticated state
+  await page.context().storageState({ path: authFile });
+});

--- a/e2e/tests/global-teardown.ts
+++ b/e2e/tests/global-teardown.ts
@@ -1,0 +1,16 @@
+import { test as teardown } from '@playwright/test';
+
+/**
+ * Global teardown — cleans up any test data created during the test run.
+ *
+ * Currently a no-op. As tests are added that create content in JCR,
+ * this file should be updated to delete test content nodes
+ * (e.g., /content/e2e-tests/*) via Sling POST servlet.
+ */
+teardown('cleanup test data', async ({ request, baseURL }) => {
+  // Future: Delete test content nodes created during the test run.
+  // Example:
+  // await request.post(`${baseURL}/content/e2e-tests`, {
+  //   form: { ':operation': 'delete' },
+  // });
+});

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke tests for Kestros CMS dev instance.
+ *
+ * These tests verify:
+ * 1. The dev instance is reachable
+ * 2. Authentication works (via storageState from global setup)
+ * 3. Core CMS endpoints respond correctly
+ *
+ * All tests are tagged @smoke so they can be run independently:
+ *   npx playwright test --grep @smoke
+ */
+test.describe('Kestros CMS Smoke Tests @smoke', () => {
+
+  test('dev instance is reachable', async ({ page }) => {
+    const response = await page.goto('/');
+    expect(response).not.toBeNull();
+    expect(response!.status()).toBeLessThan(500);
+  });
+
+  test('admin is authenticated — Felix console accessible', async ({ page }) => {
+    const response = await page.goto('/system/console/bundles');
+    expect(response).not.toBeNull();
+    expect(response!.status()).toBe(200);
+    // The Felix console page should contain bundle information
+    await expect(page.locator('body')).toContainText('Bundle');
+  });
+
+  test('Sling health check responds', async ({ request }) => {
+    const response = await request.get('/system/health', {
+      // Playwright treats non-2xx as failures by default for request API;
+      // we explicitly allow any status since 503 (unhealthy) is a valid response
+      failOnStatusCode: false,
+    });
+    // Sling health check returns 200 (healthy), 503 (unhealthy), or 404 (not configured).
+    // Any of these confirm the instance is running and responding.
+    expect([200, 404, 503]).toContain(response.status());
+  });
+
+  test('content root is accessible', async ({ request }) => {
+    const response = await request.get('/content.json');
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    // The content root should have at least a jcr:primaryType
+    expect(body).toHaveProperty('jcr:primaryType');
+  });
+
+  test('Sling POST servlet is available — can create and delete test node', async ({ request, baseURL }) => {
+    const nodeName = 'e2e-smoke-test-' + Date.now();
+    const testPath = '/content/' + nodeName;
+
+    // Create a test node via Sling POST servlet.
+    // POST to the parent (/content/) with :name parameter — Kestros CMS has a
+    // LockEnforcementServletFilter that throws 500 when POSTing directly to a
+    // non-existent path, so we must use the :name approach instead.
+    const createResponse = await request.post(`${baseURL}/content/`, {
+      form: {
+        ':name': nodeName,
+        'jcr:primaryType': 'nt:unstructured',
+        'testProperty': 'e2e-smoke-test',
+      },
+    });
+    expect(createResponse.status()).toBeLessThan(400);
+
+    // Verify the node was created
+    const getResponse = await request.get(`${baseURL}${testPath}.json`);
+    expect(getResponse.status()).toBe(200);
+    const node = await getResponse.json();
+    expect(node.testProperty).toBe('e2e-smoke-test');
+
+    // Clean up — delete the test node
+    const deleteResponse = await request.post(`${baseURL}${testPath}`, {
+      form: { ':operation': 'delete' },
+    });
+    expect(deleteResponse.status()).toBeLessThan(400);
+  });
+
+  test('login page renders', async ({ browser }) => {
+    // Use a fresh context without auth to test the login page
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const baseURL = process.env.KESTROS_CMS_URL || 'http://192.168.86.216:8000';
+
+    const response = await page.goto(`${baseURL}/system/sling/form/login`);
+    expect(response).not.toBeNull();
+    expect(response!.status()).toBe(200);
+
+    // Login page should have username and password fields
+    await expect(page.locator('input[name="j_username"]')).toBeVisible();
+    await expect(page.locator('input[name="j_password"]')).toBeVisible();
+
+    await context.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Playwright E2E testing infrastructure in `e2e/` directory
- Configured to target the Kestros CMS dev instance (port 8000)
- Global auth setup using Sling form login with `storageState` persistence across tests
- 6 smoke tests covering: instance reachability, admin auth (Felix console), health check, content root access, Sling POST servlet (create + delete), and login page rendering
- Cross-browser support (Chromium, Firefox, WebKit) with CI-ready JUnit reporter
- README documents setup, configuration, and how to run tests locally

## Test plan

- [x] All 8 tests (including setup/teardown) pass against dev instance (4.8s)
- [x] Auth setup correctly persists Sling session cookie via storageState
- [x] POST servlet test creates and cleans up JCR nodes (uses `:name` param to work with LockEnforcementServletFilter)
- [ ] Verify tests work from a clean install (`npm install && npx playwright install`)
- [ ] Verify tests run in Firefox and WebKit projects

## Notes

- `kestros-e2e-tests` dedicated repo does not exist yet (per TASK-322 recommendation). Infrastructure placed in `kestros-sample-sites/e2e/` for now. Can be moved to a dedicated repo when Danny creates it.
- TASK-322 (E2E framework evaluation spike) recommended Playwright — that task is in pending-approval.