### PR TITLE
feat: signal-conf dynamic routes + sample site content (TASK-331)

### DIFF
--- a/league-demo/pom.xml
+++ b/league-demo/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kestros.cms</groupId>
+        <artifactId>kestros-site-parent</artifactId>
+        <version>0.1.2</version>
+    </parent>
+
+    <groupId>io.kestros.samples</groupId>
+    <artifactId>league-demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <name>League Demo Sample Site</name>
+    <description>League demo sample site datasources and dynamic page support</description>
+
+    <packaging>bundle</packaging>
+
+    <properties>
+        <rootPackage>io.kestros.samples.leaguedemo</rootPackage>
+        <bundleCategory>kestros</bundleCategory>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-basic-components</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-site-building-api</artifactId>
+            <version>0.1.4-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-component-types-api</artifactId>
+            <version>0.1.3-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.samples</groupId>
+            <artifactId>league-framework-api</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.samples</groupId>
+            <artifactId>league-framework-core</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Sling-Initial-Content>
+                            /libs/kestros/samples/league-demo;overwrite:=true;path:=/libs/kestros/samples/league-demo
+                        </Sling-Initial-Content>
+                        <Sling-Model-Packages>io.kestros.samples.leaguedemo</Sling-Model-Packages>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>installBundle</id>
+        </profile>
+    </profiles>
+
+</project>

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/FixturesTableDataSource.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/FixturesTableDataSource.java
@@ -1,0 +1,77 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.samples.league.api.models.Match;
+import io.kestros.samples.league.api.models.Team;
+import io.kestros.samples.league.api.services.LeagueDataService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class FixturesTableDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosTable {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private LeagueDataService leagueDataService;
+
+  @Nonnull
+  @Override
+  public List<KestrosTableHeader> getHeaderElements() {
+    List<KestrosTableHeader> headers = new ArrayList<>();
+    try {
+      headers.add(new SyntheticTableHeader("Date", this, "header", "date"));
+      headers.add(new SyntheticTableHeader("Home", this, "header", "home"));
+      headers.add(new SyntheticTableHeader("Score", this, "header", "score"));
+      headers.add(new SyntheticTableHeader("Away", this, "header", "away"));
+    } catch (Exception e) { /* skip */ }
+    return headers;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableRow> getRowElements() {
+    List<KestrosTableRow> rows = new ArrayList<>();
+    if (leagueDataService == null) return rows;
+
+    int i = 0;
+    for (Match m : leagueDataService.getMatches()) {
+      Team home = leagueDataService.getTeam(m.getHomeTeamId());
+      Team away = leagueDataService.getTeam(m.getAwayTeamId());
+      String homeName = home != null ? home.getName() : m.getHomeTeamId();
+      String awayName = away != null ? away.getName() : m.getAwayTeamId();
+      String score = m.isPlayed()
+          ? m.getHomeScore() + " - " + m.getAwayScore()
+          : m.getDate();
+
+      try {
+        List<KestrosTableCell> cells = Arrays.asList(
+            new SyntheticTableCell(m.getDate(), this, "cell", "date-" + i),
+            new SyntheticTableCell(homeName, this, "cell", "home-" + i),
+            new SyntheticTableCell(score, this, "cell", "score-" + i),
+            new SyntheticTableCell(awayName, this, "cell", "away-" + i)
+        );
+        rows.add(new SyntheticTableRow(cells, this, "row", "row-" + i));
+        i++;
+      } catch (Exception e) { /* skip */ }
+    }
+    return rows;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(getRowElements());
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/MatchStatsTableDataSource.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/MatchStatsTableDataSource.java
@@ -1,0 +1,88 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.samples.league.api.models.Match;
+import io.kestros.samples.league.api.models.Team;
+import io.kestros.samples.league.api.services.LeagueDataService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class MatchStatsTableDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosTable {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private LeagueDataService leagueDataService;
+
+  private Match getMatch() {
+    if (leagueDataService == null) return null;
+    String id = (String) getRequest().getAttribute("match-id");
+    return id != null ? leagueDataService.getMatch(id) : null;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableHeader> getHeaderElements() {
+    List<KestrosTableHeader> headers = new ArrayList<>();
+    Match match = getMatch();
+    if (match == null || leagueDataService == null) return headers;
+
+    Team home = leagueDataService.getTeam(match.getHomeTeamId());
+    Team away = leagueDataService.getTeam(match.getAwayTeamId());
+    try {
+      headers.add(new SyntheticTableHeader(home != null ? home.getName() : "", this, "header", "home"));
+      headers.add(new SyntheticTableHeader("", this, "header", "stat"));
+      headers.add(new SyntheticTableHeader(away != null ? away.getName() : "", this, "header", "away"));
+    } catch (Exception e) { /* skip */ }
+    return headers;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableRow> getRowElements() {
+    List<KestrosTableRow> rows = new ArrayList<>();
+    Match match = getMatch();
+    if (match == null) return rows;
+
+    // Placeholder stats — in a real implementation these would come from match data
+    String[][] stats = {
+        {"58%", "Possession", "42%"},
+        {"14", "Shots", "9"},
+        {"7", "Shots on target", "3"},
+        {"6", "Corners", "4"},
+        {"11", "Fouls", "14"},
+    };
+
+    int i = 0;
+    for (String[] stat : stats) {
+      try {
+        List<KestrosTableCell> cells = Arrays.asList(
+            new SyntheticTableCell(stat[0], this, "cell", "home-" + i),
+            new SyntheticTableCell(stat[1], this, "cell", "label-" + i),
+            new SyntheticTableCell(stat[2], this, "cell", "away-" + i)
+        );
+        rows.add(new SyntheticTableRow(cells, this, "row", "row-" + i));
+        i++;
+      } catch (Exception e) { /* skip */ }
+    }
+    return rows;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(getRowElements());
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/PlayerGameLogTableDataSource.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/PlayerGameLogTableDataSource.java
@@ -1,0 +1,105 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.samples.league.api.models.Match;
+import io.kestros.samples.league.api.models.Player;
+import io.kestros.samples.league.api.models.Team;
+import io.kestros.samples.league.api.services.LeagueDataService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class PlayerGameLogTableDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosTable {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private LeagueDataService leagueDataService;
+
+  private Player getPlayer() {
+    if (leagueDataService == null) {
+      return null;
+    }
+    String slug = (String) getRequest().getAttribute("player-slug");
+    if (slug == null) {
+      return null;
+    }
+    return leagueDataService.getPlayer(slug);
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableHeader> getHeaderElements() {
+    List<KestrosTableHeader> headers = new ArrayList<>();
+    try {
+      headers.add(new SyntheticTableHeader("Wk", this, "header", "wk"));
+      headers.add(new SyntheticTableHeader("Opponent", this, "header", "opp"));
+      headers.add(new SyntheticTableHeader("Venue", this, "header", "venue"));
+      headers.add(new SyntheticTableHeader("Min", this, "header", "min"));
+      headers.add(new SyntheticTableHeader("G", this, "header", "goals"));
+      headers.add(new SyntheticTableHeader("A", this, "header", "assists"));
+    } catch (Exception e) {
+      // null-safe
+    }
+    return headers;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableRow> getRowElements() {
+    List<KestrosTableRow> rows = new ArrayList<>();
+    Player player = getPlayer();
+    if (player == null || leagueDataService == null) {
+      return rows;
+    }
+
+    int rowIndex = 0;
+    for (Match match : leagueDataService.getMatches()) {
+      if (!match.isPlayed()) {
+        continue;
+      }
+      String teamId = player.getTeamId();
+      if (!teamId.equals(match.getHomeTeamId()) && !teamId.equals(match.getAwayTeamId())) {
+        continue;
+      }
+      boolean isHome = teamId.equals(match.getHomeTeamId());
+      String oppId = isHome ? match.getAwayTeamId() : match.getHomeTeamId();
+      Team opp = leagueDataService.getTeam(oppId);
+      String oppName = opp != null ? opp.getName() : oppId;
+      String venue = isHome ? "H" : "A";
+
+      try {
+        List<KestrosTableCell> cells = Arrays.asList(
+            new SyntheticTableCell("W" + match.getMatchday(), this, "cell", "wk-" + rowIndex),
+            new SyntheticTableCell(oppName, this, "cell", "opp-" + rowIndex),
+            new SyntheticTableCell(venue, this, "cell", "venue-" + rowIndex),
+            new SyntheticTableCell("90'", this, "cell", "min-" + rowIndex),
+            new SyntheticTableCell("-", this, "cell", "goals-" + rowIndex),
+            new SyntheticTableCell("-", this, "cell", "assists-" + rowIndex)
+        );
+        rows.add(new SyntheticTableRow(cells, this, "row", "row-" + rowIndex));
+        rowIndex++;
+      } catch (Exception e) {
+        // skip on error
+      }
+    }
+    return rows;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(getRowElements());
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/PlayerStatsCardListDataSource.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/PlayerStatsCardListDataSource.java
@@ -1,0 +1,62 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
+import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
+import io.kestros.samples.league.api.models.Player;
+import io.kestros.samples.league.api.services.LeagueDataService;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class PlayerStatsCardListDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosCardList {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private LeagueDataService leagueDataService;
+
+  private Player getPlayer() {
+    if (leagueDataService == null) return null;
+    String slug = (String) getRequest().getAttribute("player-slug");
+    return slug != null ? leagueDataService.getPlayer(slug) : null;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosCard> getCardElements() {
+    List<KestrosCard> cards = new ArrayList<>();
+    Player player = getPlayer();
+    if (player == null) return cards;
+
+    // For now stats are placeholder - will be enriched with actual per-player stats later
+    String[][] stats = {
+        {"Apps", "12"},
+        {"Goals", "8"},
+        {"Assists", "3"},
+        {"Mins/Goal", "135"},
+    };
+
+    int i = 0;
+    for (String[] stat : stats) {
+      try {
+        cards.add(new KestrosCardImpl(
+            stat[1],
+            new KestrosHeadingImpl(stat[0], "h4", this, "title", "stat-title-" + i),
+            null, null,
+            this, "card", "stat-" + i));
+        i++;
+      } catch (Exception e) {
+        // skip on error
+      }
+    }
+    return cards;
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/StandingsTableDataSource.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/StandingsTableDataSource.java
@@ -1,0 +1,127 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.samples.league.api.models.Match;
+import io.kestros.samples.league.api.models.Team;
+import io.kestros.samples.league.api.services.LeagueDataService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class StandingsTableDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosTable {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private LeagueDataService leagueDataService;
+
+  private static class Standing implements Comparable<Standing> {
+    String teamId;
+    int played, won, drawn, lost, goalsFor, goalsAgainst;
+    int points() { return won * 3 + drawn; }
+    int goalDifference() { return goalsFor - goalsAgainst; }
+
+    @Override
+    public int compareTo(Standing o) {
+      if (o.points() != points()) return o.points() - points();
+      return o.goalDifference() - goalDifference();
+    }
+  }
+
+  private List<Standing> computeStandings() {
+    Map<String, Standing> map = new HashMap<>();
+    if (leagueDataService == null) return new ArrayList<>();
+
+    for (Team t : leagueDataService.getTeams()) {
+      Standing s = new Standing();
+      s.teamId = t.getId();
+      map.put(t.getId(), s);
+    }
+
+    for (Match m : leagueDataService.getMatches()) {
+      if (!m.isPlayed()) continue;
+      Standing home = map.get(m.getHomeTeamId());
+      Standing away = map.get(m.getAwayTeamId());
+      if (home == null || away == null) continue;
+
+      home.played++; away.played++;
+      home.goalsFor += m.getHomeScore(); home.goalsAgainst += m.getAwayScore();
+      away.goalsFor += m.getAwayScore(); away.goalsAgainst += m.getHomeScore();
+
+      if (m.getHomeScore() > m.getAwayScore()) { home.won++; away.lost++; }
+      else if (m.getHomeScore() < m.getAwayScore()) { away.won++; home.lost++; }
+      else { home.drawn++; away.drawn++; }
+    }
+
+    List<Standing> standings = new ArrayList<>(map.values());
+    standings.sort(null);
+    return standings;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableHeader> getHeaderElements() {
+    List<KestrosTableHeader> headers = new ArrayList<>();
+    try {
+      headers.add(new SyntheticTableHeader("#", this, "header", "pos"));
+      headers.add(new SyntheticTableHeader("Club", this, "header", "club"));
+      headers.add(new SyntheticTableHeader("P", this, "header", "played"));
+      headers.add(new SyntheticTableHeader("W", this, "header", "won"));
+      headers.add(new SyntheticTableHeader("D", this, "header", "drawn"));
+      headers.add(new SyntheticTableHeader("L", this, "header", "lost"));
+      headers.add(new SyntheticTableHeader("GD", this, "header", "gd"));
+      headers.add(new SyntheticTableHeader("Pts", this, "header", "pts"));
+    } catch (Exception e) { /* skip */ }
+    return headers;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableRow> getRowElements() {
+    List<KestrosTableRow> rows = new ArrayList<>();
+    List<Standing> standings = computeStandings();
+
+    int pos = 0;
+    for (Standing s : standings) {
+      pos++;
+      Team team = leagueDataService.getTeam(s.teamId);
+      String name = team != null ? team.getName() : s.teamId;
+      int gd = s.goalDifference();
+      String gdStr = (gd > 0 ? "+" : "") + gd;
+
+      try {
+        List<KestrosTableCell> cells = Arrays.asList(
+            new SyntheticTableCell(String.valueOf(pos), this, "cell", "pos-" + pos),
+            new SyntheticTableCell(name, this, "cell", "club-" + pos),
+            new SyntheticTableCell(String.valueOf(s.played), this, "cell", "p-" + pos),
+            new SyntheticTableCell(String.valueOf(s.won), this, "cell", "w-" + pos),
+            new SyntheticTableCell(String.valueOf(s.drawn), this, "cell", "d-" + pos),
+            new SyntheticTableCell(String.valueOf(s.lost), this, "cell", "l-" + pos),
+            new SyntheticTableCell(gdStr, this, "cell", "gd-" + pos),
+            new SyntheticTableCell(String.valueOf(s.points()), this, "cell", "pts-" + pos)
+        );
+        rows.add(new SyntheticTableRow(cells, this, "row", "row-" + pos));
+      } catch (Exception e) { /* skip */ }
+    }
+    return rows;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(getRowElements());
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/SyntheticTableCell.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/SyntheticTableCell.java
@@ -1,0 +1,35 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SyntheticTableCell extends BaseContainerSyntheticResource implements KestrosTableCell {
+
+  private final String text;
+
+  public SyntheticTableCell(@Nonnull String text,
+      @Nonnull BaseSlingModelDataSource dataSource,
+      @Nonnull String resourcePrefix,
+      @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = text;
+  }
+
+  @Nullable
+  public String getText() {
+    return text;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getCellContentElements() {
+    return new ArrayList<>();
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/SyntheticTableHeader.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/SyntheticTableHeader.java
@@ -1,0 +1,27 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import io.kestros.cms.components.basic.core.BaseSyntheticResource;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SyntheticTableHeader extends BaseSyntheticResource implements KestrosTableHeader {
+
+  private final String text;
+
+  public SyntheticTableHeader(@Nonnull String text,
+      @Nonnull BaseSlingModelDataSource dataSource,
+      @Nonnull String resourcePrefix,
+      @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = text;
+  }
+
+  @Nullable
+  @Override
+  public String getText() {
+    return text;
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/SyntheticTableRow.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/SyntheticTableRow.java
@@ -1,0 +1,37 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SyntheticTableRow extends BaseContainerSyntheticResource implements KestrosTableRow {
+
+  private final List<KestrosTableCell> cells;
+
+  public SyntheticTableRow(@Nonnull List<KestrosTableCell> cells,
+      @Nonnull BaseSlingModelDataSource dataSource,
+      @Nonnull String resourcePrefix,
+      @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.cells = cells;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableCell> getCellElements() {
+    return new ArrayList<>(cells);
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(cells);
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/TeamFormTableDataSource.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/TeamFormTableDataSource.java
@@ -1,0 +1,88 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.samples.league.api.models.Match;
+import io.kestros.samples.league.api.models.Team;
+import io.kestros.samples.league.api.services.LeagueDataService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class TeamFormTableDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosTable {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private LeagueDataService leagueDataService;
+
+  @Nonnull
+  @Override
+  public List<KestrosTableHeader> getHeaderElements() {
+    List<KestrosTableHeader> headers = new ArrayList<>();
+    try {
+      headers.add(new SyntheticTableHeader("Date", this, "header", "date"));
+      headers.add(new SyntheticTableHeader("Opponent", this, "header", "opp"));
+      headers.add(new SyntheticTableHeader("Venue", this, "header", "venue"));
+      headers.add(new SyntheticTableHeader("Result", this, "header", "result"));
+      headers.add(new SyntheticTableHeader("Score", this, "header", "score"));
+    } catch (Exception e) { /* skip */ }
+    return headers;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableRow> getRowElements() {
+    List<KestrosTableRow> rows = new ArrayList<>();
+    if (leagueDataService == null) return rows;
+
+    String slug = (String) getRequest().getAttribute("team-slug");
+    if (slug == null) return rows;
+
+    int i = 0;
+    for (Match m : leagueDataService.getMatches()) {
+      if (!m.isPlayed()) continue;
+      if (!slug.equals(m.getHomeTeamId()) && !slug.equals(m.getAwayTeamId())) continue;
+
+      boolean isHome = slug.equals(m.getHomeTeamId());
+      String oppId = isHome ? m.getAwayTeamId() : m.getHomeTeamId();
+      Team opp = leagueDataService.getTeam(oppId);
+      String oppName = opp != null ? opp.getName() : oppId;
+      String venue = isHome ? "H" : "A";
+
+      int teamGoals = isHome ? m.getHomeScore() : m.getAwayScore();
+      int oppGoals = isHome ? m.getAwayScore() : m.getHomeScore();
+      String result = teamGoals > oppGoals ? "W" : teamGoals < oppGoals ? "L" : "D";
+      String score = teamGoals + "-" + oppGoals;
+
+      try {
+        List<KestrosTableCell> cells = Arrays.asList(
+            new SyntheticTableCell(m.getDate(), this, "cell", "date-" + i),
+            new SyntheticTableCell(oppName, this, "cell", "opp-" + i),
+            new SyntheticTableCell(venue, this, "cell", "venue-" + i),
+            new SyntheticTableCell(result, this, "cell", "result-" + i),
+            new SyntheticTableCell(score, this, "cell", "score-" + i)
+        );
+        rows.add(new SyntheticTableRow(cells, this, "row", "row-" + i));
+        i++;
+      } catch (Exception e) { /* skip */ }
+    }
+    return rows;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(getRowElements());
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/TeamRosterTableDataSource.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/TeamRosterTableDataSource.java
@@ -1,0 +1,69 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.samples.league.api.models.Player;
+import io.kestros.samples.league.api.services.LeagueDataService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class TeamRosterTableDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosTable {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private LeagueDataService leagueDataService;
+
+  @Nonnull
+  @Override
+  public List<KestrosTableHeader> getHeaderElements() {
+    List<KestrosTableHeader> headers = new ArrayList<>();
+    try {
+      headers.add(new SyntheticTableHeader("#", this, "header", "num"));
+      headers.add(new SyntheticTableHeader("Name", this, "header", "name"));
+      headers.add(new SyntheticTableHeader("Position", this, "header", "pos"));
+    } catch (Exception e) { /* skip */ }
+    return headers;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableRow> getRowElements() {
+    List<KestrosTableRow> rows = new ArrayList<>();
+    if (leagueDataService == null) return rows;
+
+    String slug = (String) getRequest().getAttribute("team-slug");
+    if (slug == null) return rows;
+
+    int i = 0;
+    for (Player p : leagueDataService.getPlayersByTeam(slug)) {
+      try {
+        List<KestrosTableCell> cells = Arrays.asList(
+            new SyntheticTableCell(String.valueOf(p.getNumber()), this, "cell", "num-" + i),
+            new SyntheticTableCell(p.getFirstName() + " " + p.getLastName(), this, "cell", "name-" + i),
+            new SyntheticTableCell(p.getPosition(), this, "cell", "pos-" + i)
+        );
+        rows.add(new SyntheticTableRow(cells, this, "row", "row-" + i));
+        i++;
+      } catch (Exception e) { /* skip */ }
+    }
+    return rows;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(getRowElements());
+  }
+}

--- a/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/TeamsCardListDataSource.java
+++ b/league-demo/src/main/java/io/kestros/samples/leaguedemo/datasources/TeamsCardListDataSource.java
@@ -1,0 +1,47 @@
+package io.kestros.samples.leaguedemo.datasources;
+
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
+import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
+import io.kestros.samples.league.api.models.Team;
+import io.kestros.samples.league.api.services.LeagueDataService;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class TeamsCardListDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosCardList {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private LeagueDataService leagueDataService;
+
+  @Nonnull
+  @Override
+  public List<KestrosCard> getCardElements() {
+    List<KestrosCard> cards = new ArrayList<>();
+    if (leagueDataService == null) return cards;
+
+    int i = 0;
+    for (Team team : leagueDataService.getTeams()) {
+      try {
+        cards.add(new KestrosCardImpl(
+            team.getCity() + " - " + team.getStadium(),
+            new KestrosHeadingImpl(team.getName(), "h3", this, "title", "team-title-" + i),
+            null, null,
+            this, "card", "team-" + i));
+        i++;
+      } catch (Exception e) {
+        // skip on error
+      }
+    }
+    return cards;
+  }
+}

--- a/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/fixtures.json
+++ b/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/fixtures.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Fixtures",
+  "group": "League Demo",
+  "classPath": "io.kestros.samples.leaguedemo.datasources.FixturesTableDataSource",
+  "container": true
+}

--- a/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/match-stats.json
+++ b/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/match-stats.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Match Stats",
+  "group": "League Demo",
+  "classPath": "io.kestros.samples.leaguedemo.datasources.MatchStatsTableDataSource",
+  "container": true
+}

--- a/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/player-game-log.json
+++ b/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/player-game-log.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Player Game Log",
+  "group": "League Demo",
+  "classPath": "io.kestros.samples.leaguedemo.datasources.PlayerGameLogTableDataSource",
+  "container": true
+}

--- a/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/player-stats.json
+++ b/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/player-stats.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Player Stats",
+  "group": "League Demo",
+  "classPath": "io.kestros.samples.leaguedemo.datasources.PlayerStatsCardListDataSource",
+  "container": true
+}

--- a/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/standings.json
+++ b/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/standings.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "League Standings",
+  "group": "League Demo",
+  "classPath": "io.kestros.samples.leaguedemo.datasources.StandingsTableDataSource",
+  "container": true
+}

--- a/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/team-form.json
+++ b/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/team-form.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Team Recent Form",
+  "group": "League Demo",
+  "classPath": "io.kestros.samples.leaguedemo.datasources.TeamFormTableDataSource",
+  "container": true
+}

--- a/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/team-roster.json
+++ b/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/team-roster.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Team Roster",
+  "group": "League Demo",
+  "classPath": "io.kestros.samples.leaguedemo.datasources.TeamRosterTableDataSource",
+  "container": true
+}

--- a/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/teams-list.json
+++ b/league-demo/src/main/resources/libs/kestros/samples/league-demo/datasources/teams-list.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Teams List",
+  "group": "League Demo",
+  "classPath": "io.kestros.samples.leaguedemo.datasources.TeamsCardListDataSource",
+  "container": true
+}

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 <!--    <module>resolve-2021</module>-->
     <module>basic-components-sample</module>
     <module>signal-conf</module>
+    <module>league-demo</module>
   </modules>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <module>explore</module>
 <!--    <module>resolve-2021</module>-->
     <module>basic-components-sample</module>
+    <module>signal-conf</module>
   </modules>
 
   <dependencyManagement>

--- a/signal-conf/pom.xml
+++ b/signal-conf/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kestros.cms</groupId>
+        <artifactId>kestros-site-parent</artifactId>
+        <version>0.1.2</version>
+    </parent>
+
+    <groupId>io.kestros.samples</groupId>
+    <artifactId>signal-conf</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <name>Signal Conf Sample Site</name>
+    <description>Signal conference sample site demonstrating custom datasources</description>
+
+    <packaging>bundle</packaging>
+
+    <properties>
+        <rootPackage>io.kestros.samples.signalconf</rootPackage>
+        <bundleCategory>kestros</bundleCategory>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-basic-components</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-site-building-api</artifactId>
+            <version>0.1.4-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-component-types-api</artifactId>
+            <version>0.1.3-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-tagging-api</artifactId>
+            <version>[0.1.3,0.1.99]</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/content/jcr_root</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <version>1.3.6</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                            <goal>package</goal>
+                            <goal>analyze-classes</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packageType>mixed</packageType>
+                    <failOnMissingEmbed>true</failOnMissingEmbed>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <allowIndexDefinitions>true</allowIndexDefinitions>
+                    <filterSource>${basedir}/src/content/META-INF/vault/filter.xml</filterSource>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Sling-Initial-Content>
+                            /libs/kestros/samples/signal-conf;overwrite:=true;path:=/libs/kestros/samples/signal-conf,
+                            /content/sites;overwrite:=true;path:=/content/sites
+                        </Sling-Initial-Content>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>installPackage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.wcm.maven.plugins</groupId>
+                        <artifactId>wcmio-content-package-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <serviceURL>
+                                ${sling.protocol}://${sling.host}:${sling.port}/bin/cpm/package.service.html
+                            </serviceURL>
+                            <userId>${sling.username}</userId>
+                            <password>${sling.password}</password>
+                            <packageFile>target/${project.artifactId}-${project.version}.zip
+                            </packageFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>installBundle</id>
+        </profile>
+    </profiles>
+
+</project>

--- a/signal-conf/pom.xml
+++ b/signal-conf/pom.xml
@@ -89,9 +89,9 @@
                 <configuration>
                     <instructions>
                         <Sling-Initial-Content>
-                            /libs/kestros/samples/signal-conf;overwrite:=true;path:=/libs/kestros/samples/signal-conf,
-                            /content/sites;overwrite:=true;path:=/content/sites
+                            /libs/kestros/samples/signal-conf;overwrite:=true;path:=/libs/kestros/samples/signal-conf
                         </Sling-Initial-Content>
+                        <Sling-Model-Packages>io.kestros.samples.signalconf</Sling-Model-Packages>
                     </instructions>
                 </configuration>
             </plugin>

--- a/signal-conf/src/content/META-INF/vault/config.xml
+++ b/signal-conf/src/content/META-INF/vault/config.xml
@@ -1,0 +1,37 @@
+<vaultfs version="1.1">
+    <aggregates>
+        <aggregate type="file" title="File Aggregate"/>
+        <aggregate type="filefolder" title="File/Folder Aggregate"/>
+        <aggregate type="nodetype" title="Node Type Aggregate" />
+        <aggregate type="full" title="Full Coverage Aggregate">
+            <matches>
+                <include nodeType="rep:AccessControl" respectSupertype="true" />
+                <include nodeType="rep:Policy" respectSupertype="true" />
+                <include nodeType="vlt:FullCoverage" respectSupertype="true" />
+                <include nodeType="mix:language" respectSupertype="true" />
+                <include nodeType="sling:OsgiConfig" respectSupertype="true" />
+            </matches>
+        </aggregate>
+        <aggregate type="generic" title="Folder Aggregate">
+            <matches>
+                <include nodeType="nt:folder" respectSupertype="true" />
+            </matches>
+            <contains>
+                <exclude isNode="true" />
+            </contains>
+        </aggregate>
+        <aggregate type="generic" title="Default Aggregator" isDefault="true">
+            <matches>
+            </matches>
+            <contains>
+                <exclude nodeType="nt:hierarchyNode" respectSupertype="true" />
+            </contains>
+        </aggregate>
+    </aggregates>
+    <handlers>
+        <handler type="folder"/>
+        <handler type="file"/>
+        <handler type="nodetype"/>
+        <handler type="generic"/>
+    </handlers>
+</vaultfs>

--- a/signal-conf/src/content/META-INF/vault/filter.xml
+++ b/signal-conf/src/content/META-INF/vault/filter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workspaceFilter version="1.0">
+
+  <filter root="/content/sites/signal-conf"/>
+
+</workspaceFilter>

--- a/signal-conf/src/content/META-INF/vault/settings.xml
+++ b/signal-conf/src/content/META-INF/vault/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vault version="1.0">
+  <ignore name=".svn"/>
+  <ignore name=".git"/>
+</vault>

--- a/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
+++ b/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
@@ -1,65 +1,124 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          xmlns:kes="http://kestros.io"
+          xmlns:kes="http://kestros.io/kes/1.0"
           xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
           xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-          jcr:primaryType="kes:Site"
-          jcr:title="Signal Conf"
-          jcr:description="Signal Conference sample site demonstrating custom datasources">
+          jcr:primaryType="kes:Site">
     <jcr:content
             jcr:primaryType="nt:unstructured"
             jcr:title="Signal Conf"
-            jcr:description="Signal Conference sample site"/>
-    <presenters
-            jcr:primaryType="kes:Page"
-            jcr:title="Presenters">
-        <jcr:content
+            jcr:description="Signal Conference — a full conference site built on UIkit"
+            kes:theme="/etc/ui-frameworks/ui-kit/versions/0.0.1/themes/default"
+            sling:resourceType="kestros/commons/components/kestros-base-page"
+            publicationStrategy="kestros-single-instance">
+        <header
                 jcr:primaryType="nt:unstructured"
-                jcr:title="Presenters"
-                jcr:description="Conference presenters">
-            <card-list
+                sling:resourceType="kestros/commons/components/inherited-content-area">
+            <container
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="/libs/kestros/commons/components/lists/card-list"
-                    kes:datasource="presenters"
-                    pagesPath="/content/sites/signal-conf/presenters"
-                    readMoreText="View Sessions"/>
-        </jcr:content>
-        <alice-smith
-                jcr:primaryType="kes:Page"
-                jcr:title="Alice Smith">
-            <jcr:content
-                    jcr:primaryType="nt:unstructured"
-                    jcr:title="Alice Smith"
-                    jcr:description="Senior Developer">
-                <button-group
+                    sling:resourceType="/libs/kestros/commons/components/structure/container"
+                    elementType="header">
+                <section
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/content/button-group"
-                        kes:datasource="presenter-sessions"
-                        sessionsPath="/content/sites/signal-conf/sessions"/>
-            </jcr:content>
-        </alice-smith>
-        <bob-jones
-                jcr:primaryType="kes:Page"
-                jcr:title="Bob Jones">
-            <jcr:content
+                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        variations="[]">
+                    <page-title
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/content/page-title"
+                            level="h1"
+                            variations="[]"/>
+                    <navigation
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/navigation"
+                            variations="[]"/>
+                </section>
+            </container>
+        </header>
+        <main
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="kestros/commons/components/content-area">
+            <section
                     jcr:primaryType="nt:unstructured"
-                    jcr:title="Bob Jones"
-                    jcr:description="Lead Architect">
-                <button-group
+                    sling:resourceType="/libs/kestros/commons/components/structure/section"
+                    variations="[]">
+                <container
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/content/button-group"
-                        kes:datasource="presenter-sessions"
-                        sessionsPath="/content/sites/signal-conf/sessions"/>
-            </jcr:content>
-        </bob-jones>
-    </presenters>
+                        sling:resourceType="/libs/kestros/commons/components/structure/container"
+                        elementType="main"
+                        variations="[]">
+                    <inherited-content-area
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/inherited-content-area">
+                        <breadcrumbs
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/breadcrumbs"
+                                variations="[]"/>
+                    </inherited-content-area>
+                </container>
+            </section>
+        </main>
+        <footer
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="kestros/commons/components/inherited-content-area">
+            <container
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="/libs/kestros/commons/components/structure/container"
+                    elementType="footer">
+                <section
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        variations="[]">
+                    <heading
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/content/heading"
+                            level="h3"
+                            text="Signal Conf"
+                            variations="[]"/>
+                    <text
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/content/text"
+                            text="A Kestros CMS sample conference site built on UIkit."
+                            variations="[]"/>
+                </section>
+            </container>
+        </footer>
+    </jcr:content>
     <sessions
             jcr:primaryType="kes:Page"
             jcr:title="Sessions">
         <jcr:content
                 jcr:primaryType="nt:unstructured"
                 jcr:title="Sessions"
-                jcr:description="Conference sessions"/>
+                jcr:description="Browse all conference sessions"
+                sling:resourceType="kestros/commons/components/kestros-base-page">
+            <main
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kestros/commons/components/content-area">
+                <section
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        variations="[]">
+                    <container
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            elementType="main"
+                            variations="[]">
+                        <heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h2"
+                                text="Conference Sessions"
+                                variations="[]"/>
+                        <card-list
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                kes:datasource="presenter-sessions"
+                                pagesPath="/content/sites/signal-conf/sessions"
+                                readMoreText="View Session"/>
+                    </container>
+                </section>
+            </main>
+        </jcr:content>
         <intro-to-sling
                 jcr:primaryType="kes:Page"
                 jcr:title="Introduction to Sling">
@@ -69,14 +128,41 @@
                     jcr:description="Learn the basics of Apache Sling"
                     sessionTime="9:00 AM"
                     presenterName="Alice Smith"
-                    presenterPath="/content/sites/signal-conf/presenters/alice-smith"
-                    kes:tags="[/etc/tags/signal-conf/day-1,/etc/tags/signal-conf/topic/sling]">
-                <related-sessions
+                    presenterPath="/content/sites/signal-conf/speakers/alice-smith"
+                    kes:tags="[/etc/tags/signal-conf/day-1,/etc/tags/signal-conf/topic/sling]"
+                    sling:resourceType="kestros/commons/components/kestros-base-page">
+                <main
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/lists/card-list"
-                        kes:datasource="tag-search"
-                        pagesPath="/content/sites/signal-conf/sessions"
-                        readMoreText="View Session"/>
+                        sling:resourceType="kestros/commons/components/content-area">
+                    <section
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            variations="[]">
+                        <container
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                elementType="main"
+                                variations="[]">
+                            <heading
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                    level="h2"
+                                    text="Introduction to Sling"
+                                    variations="[]"/>
+                            <text
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    text="Learn the basics of Apache Sling in this introductory session."
+                                    variations="[]"/>
+                            <related-sessions
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                    kes:datasource="tag-search"
+                                    pagesPath="/content/sites/signal-conf/sessions"
+                                    readMoreText="View Session"/>
+                        </container>
+                    </section>
+                </main>
             </jcr:content>
         </intro-to-sling>
         <advanced-htl
@@ -88,14 +174,41 @@
                     jcr:description="Deep dive into HTL templating"
                     sessionTime="11:00 AM"
                     presenterName="Bob Jones"
-                    presenterPath="/content/sites/signal-conf/presenters/bob-jones"
-                    kes:tags="[/etc/tags/signal-conf/day-1,/etc/tags/signal-conf/topic/htl]">
-                <related-sessions
+                    presenterPath="/content/sites/signal-conf/speakers/bob-jones"
+                    kes:tags="[/etc/tags/signal-conf/day-1,/etc/tags/signal-conf/topic/htl]"
+                    sling:resourceType="kestros/commons/components/kestros-base-page">
+                <main
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/lists/card-list"
-                        kes:datasource="tag-search"
-                        pagesPath="/content/sites/signal-conf/sessions"
-                        readMoreText="View Session"/>
+                        sling:resourceType="kestros/commons/components/content-area">
+                    <section
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            variations="[]">
+                        <container
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                elementType="main"
+                                variations="[]">
+                            <heading
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                    level="h2"
+                                    text="Advanced HTL Techniques"
+                                    variations="[]"/>
+                            <text
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    text="A deep dive into advanced Sling HTL templating patterns and best practices."
+                                    variations="[]"/>
+                            <related-sessions
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                    kes:datasource="tag-search"
+                                    pagesPath="/content/sites/signal-conf/sessions"
+                                    readMoreText="View Session"/>
+                        </container>
+                    </section>
+                </main>
             </jcr:content>
         </advanced-htl>
         <osgi-services
@@ -107,36 +220,588 @@
                     jcr:description="Understanding OSGi service patterns"
                     sessionTime="2:00 PM"
                     presenterName="Alice Smith"
-                    presenterPath="/content/sites/signal-conf/presenters/alice-smith"
-                    kes:tags="[/etc/tags/signal-conf/day-2,/etc/tags/signal-conf/topic/sling]">
-                <related-sessions
+                    presenterPath="/content/sites/signal-conf/speakers/alice-smith"
+                    kes:tags="[/etc/tags/signal-conf/day-2,/etc/tags/signal-conf/topic/sling]"
+                    sling:resourceType="kestros/commons/components/kestros-base-page">
+                <main
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/lists/card-list"
-                        kes:datasource="tag-search"
-                        pagesPath="/content/sites/signal-conf/sessions"
-                        readMoreText="View Session"/>
+                        sling:resourceType="kestros/commons/components/content-area">
+                    <section
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            variations="[]">
+                        <container
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                elementType="main"
+                                variations="[]">
+                            <heading
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                    level="h2"
+                                    text="OSGi Services Deep Dive"
+                                    variations="[]"/>
+                            <text
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    text="Understanding OSGi service patterns and best practices in a Kestros/Sling context."
+                                    variations="[]"/>
+                            <related-sessions
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                    kes:datasource="tag-search"
+                                    pagesPath="/content/sites/signal-conf/sessions"
+                                    readMoreText="View Session"/>
+                        </container>
+                    </section>
+                </main>
             </jcr:content>
         </osgi-services>
+        <jcr-content-modeling
+                jcr:primaryType="kes:Page"
+                jcr:title="JCR Content Modeling">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="JCR Content Modeling"
+                    jcr:description="Best practices for modeling content in Apache Jackrabbit"
+                    sessionTime="10:00 AM"
+                    presenterName="Carol White"
+                    presenterPath="/content/sites/signal-conf/speakers/carol-white"
+                    kes:tags="[/etc/tags/signal-conf/day-2,/etc/tags/signal-conf/topic/jcr]"
+                    sling:resourceType="kestros/commons/components/kestros-base-page">
+                <main
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kestros/commons/components/content-area">
+                    <section
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            variations="[]">
+                        <container
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                elementType="main"
+                                variations="[]">
+                            <heading
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                    level="h2"
+                                    text="JCR Content Modeling"
+                                    variations="[]"/>
+                            <text
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    text="Best practices for structuring and modeling content in Apache Jackrabbit JCR repositories."
+                                    variations="[]"/>
+                        </container>
+                    </section>
+                </main>
+            </jcr:content>
+        </jcr-content-modeling>
     </sessions>
+    <speakers
+            jcr:primaryType="kes:Page"
+            jcr:title="Speakers">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Speakers"
+                jcr:description="Conference speakers and presenters"
+                sling:resourceType="kestros/commons/components/kestros-base-page">
+            <main
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kestros/commons/components/content-area">
+                <section
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        variations="[]">
+                    <container
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            elementType="main"
+                            variations="[]">
+                        <heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h2"
+                                text="Our Speakers"
+                                variations="[]"/>
+                        <card-list
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                kes:datasource="presenters"
+                                pagesPath="/content/sites/signal-conf/speakers"
+                                readMoreText="View Sessions"/>
+                    </container>
+                </section>
+            </main>
+        </jcr:content>
+        <alice-smith
+                jcr:primaryType="kes:Page"
+                jcr:title="Alice Smith">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Alice Smith"
+                    jcr:description="Senior Developer and Sling expert"
+                    sling:resourceType="kestros/commons/components/kestros-base-page">
+                <main
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kestros/commons/components/content-area">
+                    <section
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            variations="[]">
+                        <container
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                elementType="main"
+                                variations="[]">
+                            <heading
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                    level="h2"
+                                    text="Alice Smith"
+                                    variations="[]"/>
+                            <text
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    text="Senior Developer specializing in Apache Sling and OSGi services."
+                                    variations="[]"/>
+                            <button-group
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                                    kes:datasource="presenter-sessions"
+                                    sessionsPath="/content/sites/signal-conf/sessions"/>
+                        </container>
+                    </section>
+                </main>
+            </jcr:content>
+        </alice-smith>
+        <bob-jones
+                jcr:primaryType="kes:Page"
+                jcr:title="Bob Jones">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Bob Jones"
+                    jcr:description="Lead Architect and HTL specialist"
+                    sling:resourceType="kestros/commons/components/kestros-base-page">
+                <main
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kestros/commons/components/content-area">
+                    <section
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            variations="[]">
+                        <container
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                elementType="main"
+                                variations="[]">
+                            <heading
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                    level="h2"
+                                    text="Bob Jones"
+                                    variations="[]"/>
+                            <text
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    text="Lead Architect with deep expertise in HTL templating and Kestros component design."
+                                    variations="[]"/>
+                            <button-group
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                                    kes:datasource="presenter-sessions"
+                                    sessionsPath="/content/sites/signal-conf/sessions"/>
+                        </container>
+                    </section>
+                </main>
+            </jcr:content>
+        </bob-jones>
+        <carol-white
+                jcr:primaryType="kes:Page"
+                jcr:title="Carol White">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Carol White"
+                    jcr:description="JCR Content Modeling expert"
+                    sling:resourceType="kestros/commons/components/kestros-base-page">
+                <main
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kestros/commons/components/content-area">
+                    <section
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            variations="[]">
+                        <container
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                elementType="main"
+                                variations="[]">
+                            <heading
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                    level="h2"
+                                    text="Carol White"
+                                    variations="[]"/>
+                            <text
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    text="JCR Content Modeling expert with years of experience designing Jackrabbit repository structures."
+                                    variations="[]"/>
+                            <button-group
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                                    kes:datasource="presenter-sessions"
+                                    sessionsPath="/content/sites/signal-conf/sessions"/>
+                        </container>
+                    </section>
+                </main>
+            </jcr:content>
+        </carol-white>
+    </speakers>
+    <sponsors
+            jcr:primaryType="kes:Page"
+            jcr:title="Sponsors">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Sponsors"
+                jcr:description="Signal Conf sponsors and partners"
+                sling:resourceType="kestros/commons/components/kestros-base-page">
+            <main
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kestros/commons/components/content-area">
+                <section
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        variations="[]">
+                    <container
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            elementType="main"
+                            variations="[]">
+                        <heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h2"
+                                text="Our Sponsors"
+                                variations="[]"/>
+                        <text
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/text"
+                                text="Signal Conf is made possible by the generous support of our sponsors."
+                                variations="[]"/>
+                        <platinum-heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h3"
+                                text="Platinum Sponsors"
+                                variations="[]"/>
+                        <grid
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/grid"
+                                variations="[]">
+                            <column-1
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="Kestros IO"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="Open-source CMS built on Apache Sling."
+                                        variations="[]"/>
+                                <button
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/button"
+                                        href="https://kestros.io"
+                                        label="Visit Kestros"
+                                        text="Visit Kestros"
+                                        variations="[]"/>
+                            </column-1>
+                            <column-2
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="Apache Software Foundation"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="The home of Apache Sling, Jackrabbit, and Felix."
+                                        variations="[]"/>
+                                <button
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/button"
+                                        href="https://apache.org"
+                                        label="Visit ASF"
+                                        text="Visit ASF"
+                                        variations="[]"/>
+                            </column-2>
+                        </grid>
+                        <gold-heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h3"
+                                text="Gold Sponsors"
+                                variations="[]"/>
+                        <grid-gold
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/grid"
+                                variations="[]">
+                            <column-1
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="UIkit"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="A lightweight and modular front-end framework."
+                                        variations="[]"/>
+                            </column-1>
+                            <column-2
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="OSGi Alliance"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="The specification body behind the OSGi framework."
+                                        variations="[]"/>
+                            </column-2>
+                        </grid-gold>
+                    </container>
+                </section>
+            </main>
+        </jcr:content>
+    </sponsors>
     <schedule
             jcr:primaryType="kes:Page"
             jcr:title="Schedule">
         <jcr:content
                 jcr:primaryType="nt:unstructured"
                 jcr:title="Schedule"
-                jcr:description="Conference schedule">
-            <day-1-table
+                jcr:description="Conference schedule"
+                sling:resourceType="kestros/commons/components/kestros-base-page">
+            <main
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="/libs/kestros/commons/components/content/table"
-                    kes:datasource="schedule"
-                    sessionsPath="/content/sites/signal-conf/sessions"
-                    dayTag="/etc/tags/signal-conf/day-1"/>
-            <day-2-table
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="/libs/kestros/commons/components/content/table"
-                    kes:datasource="schedule"
-                    sessionsPath="/content/sites/signal-conf/sessions"
-                    dayTag="/etc/tags/signal-conf/day-2"/>
+                    sling:resourceType="kestros/commons/components/content-area">
+                <section
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        variations="[]">
+                    <container
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            elementType="main"
+                            variations="[]">
+                        <heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h2"
+                                text="Conference Schedule"
+                                variations="[]"/>
+                        <day-1-heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h3"
+                                text="Day 1"
+                                variations="[]"/>
+                        <day-1-table
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/table"
+                                kes:datasource="schedule"
+                                sessionsPath="/content/sites/signal-conf/sessions"
+                                dayTag="/etc/tags/signal-conf/day-1"/>
+                        <day-2-heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h3"
+                                text="Day 2"
+                                variations="[]"/>
+                        <day-2-table
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/table"
+                                kes:datasource="schedule"
+                                sessionsPath="/content/sites/signal-conf/sessions"
+                                dayTag="/etc/tags/signal-conf/day-2"/>
+                    </container>
+                </section>
+            </main>
         </jcr:content>
     </schedule>
+    <venue
+            jcr:primaryType="kes:Page"
+            jcr:title="Venue">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Venue"
+                jcr:description="Signal Conf venue and location information"
+                sling:resourceType="kestros/commons/components/kestros-base-page">
+            <main
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kestros/commons/components/content-area">
+                <section
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        variations="[]">
+                    <container
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            elementType="main"
+                            variations="[]">
+                        <heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h2"
+                                text="Conference Venue"
+                                variations="[]"/>
+                        <text
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/text"
+                                text="Signal Conf takes place at the Kestros Convention Center, located in the heart of downtown."
+                                variations="[]"/>
+                        <address-heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h3"
+                                text="Address"
+                                variations="[]"/>
+                        <address-text
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/text"
+                                text="123 Sling Avenue, Suite 100, Apache City, CA 94105"
+                                variations="[]"/>
+                        <getting-there-heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h3"
+                                text="Getting There"
+                                variations="[]"/>
+                        <grid
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/grid"
+                                variations="[]">
+                            <column-1
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="By Public Transit"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="Take the Blue Line to Convention Center Station. Exit at Main Street and walk 2 blocks north."
+                                        variations="[]"/>
+                            </column-1>
+                            <column-2
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="By Car"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="Parking is available in the Kestros Convention Center garage at 125 Sling Avenue. Daily rate applies."
+                                        variations="[]"/>
+                            </column-2>
+                            <column-3
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="Nearby Hotels"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="The Jackrabbit Inn (0.2 miles) and Sling Hotel (0.5 miles) offer conference rates. Use code SIGNALCONF at booking."
+                                        variations="[]"/>
+                            </column-3>
+                        </grid>
+                        <rooms-heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                level="h3"
+                                text="Meeting Rooms"
+                                variations="[]"/>
+                        <grid-rooms
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="/libs/kestros/commons/components/structure/grid"
+                                variations="[]">
+                            <column-1
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="Main Hall"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="Capacity: 500. Keynotes and main track sessions."
+                                        variations="[]"/>
+                            </column-1>
+                            <column-2
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="Room A — Sling"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="Capacity: 120. Technical breakout sessions."
+                                        variations="[]"/>
+                            </column-2>
+                            <column-3
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="kestros/commons/components/content-area">
+                                <heading
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
+                                        level="h4"
+                                        text="Room B — Felix"
+                                        variations="[]"/>
+                                <text
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        text="Capacity: 80. Workshops and hands-on labs."
+                                        variations="[]"/>
+                            </column-3>
+                        </grid-rooms>
+                    </container>
+                </section>
+            </main>
+        </jcr:content>
+    </venue>
 </jcr:root>

--- a/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
+++ b/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io"
+          xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="kes:Site"
+          jcr:title="Signal Conf"
+          jcr:description="Signal Conference sample site demonstrating custom datasources">
+    <jcr:content
+            jcr:primaryType="nt:unstructured"
+            jcr:title="Signal Conf"
+            jcr:description="Signal Conference sample site"/>
+    <presenters
+            jcr:primaryType="kes:Page"
+            jcr:title="Presenters">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Presenters"
+                jcr:description="Conference presenters">
+            <card-list
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                    kes:datasource="presenters"
+                    pagesPath="/content/sites/signal-conf/presenters"
+                    readMoreText="View Sessions"/>
+        </jcr:content>
+        <alice-smith
+                jcr:primaryType="kes:Page"
+                jcr:title="Alice Smith">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Alice Smith"
+                    jcr:description="Senior Developer">
+                <button-group
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                        kes:datasource="presenter-sessions"
+                        sessionsPath="/content/sites/signal-conf/sessions"/>
+            </jcr:content>
+        </alice-smith>
+        <bob-jones
+                jcr:primaryType="kes:Page"
+                jcr:title="Bob Jones">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Bob Jones"
+                    jcr:description="Lead Architect">
+                <button-group
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                        kes:datasource="presenter-sessions"
+                        sessionsPath="/content/sites/signal-conf/sessions"/>
+            </jcr:content>
+        </bob-jones>
+    </presenters>
+    <sessions
+            jcr:primaryType="kes:Page"
+            jcr:title="Sessions">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Sessions"
+                jcr:description="Conference sessions"/>
+        <intro-to-sling
+                jcr:primaryType="kes:Page"
+                jcr:title="Introduction to Sling">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Introduction to Sling"
+                    jcr:description="Learn the basics of Apache Sling"
+                    sessionTime="9:00 AM"
+                    presenterName="Alice Smith"
+                    presenterPath="/content/sites/signal-conf/presenters/alice-smith"
+                    kes:tags="[/etc/tags/signal-conf/day-1,/etc/tags/signal-conf/topic/sling]">
+                <related-sessions
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                        kes:datasource="tag-search"
+                        pagesPath="/content/sites/signal-conf/sessions"
+                        readMoreText="View Session"/>
+            </jcr:content>
+        </intro-to-sling>
+        <advanced-htl
+                jcr:primaryType="kes:Page"
+                jcr:title="Advanced HTL Techniques">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Advanced HTL Techniques"
+                    jcr:description="Deep dive into HTL templating"
+                    sessionTime="11:00 AM"
+                    presenterName="Bob Jones"
+                    presenterPath="/content/sites/signal-conf/presenters/bob-jones"
+                    kes:tags="[/etc/tags/signal-conf/day-1,/etc/tags/signal-conf/topic/htl]">
+                <related-sessions
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                        kes:datasource="tag-search"
+                        pagesPath="/content/sites/signal-conf/sessions"
+                        readMoreText="View Session"/>
+            </jcr:content>
+        </advanced-htl>
+        <osgi-services
+                jcr:primaryType="kes:Page"
+                jcr:title="OSGi Services Deep Dive">
+            <jcr:content
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="OSGi Services Deep Dive"
+                    jcr:description="Understanding OSGi service patterns"
+                    sessionTime="2:00 PM"
+                    presenterName="Alice Smith"
+                    presenterPath="/content/sites/signal-conf/presenters/alice-smith"
+                    kes:tags="[/etc/tags/signal-conf/day-2,/etc/tags/signal-conf/topic/sling]">
+                <related-sessions
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                        kes:datasource="tag-search"
+                        pagesPath="/content/sites/signal-conf/sessions"
+                        readMoreText="View Session"/>
+            </jcr:content>
+        </osgi-services>
+    </sessions>
+    <schedule
+            jcr:primaryType="kes:Page"
+            jcr:title="Schedule">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Schedule"
+                jcr:description="Conference schedule">
+            <day-1-table
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="/libs/kestros/commons/components/content/table"
+                    kes:datasource="schedule"
+                    sessionsPath="/content/sites/signal-conf/sessions"
+                    dayTag="/etc/tags/signal-conf/day-1"/>
+            <day-2-table
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="/libs/kestros/commons/components/content/table"
+                    kes:datasource="schedule"
+                    sessionsPath="/content/sites/signal-conf/sessions"
+                    dayTag="/etc/tags/signal-conf/day-2"/>
+        </jcr:content>
+    </schedule>
+</jcr:root>

--- a/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
+++ b/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
@@ -83,8 +83,7 @@
         </footer>
     </jcr:content>
     <sessions
-            jcr:primaryType="kes:Page"
-            jcr:title="Sessions">
+            jcr:primaryType="kes:Page">
         <jcr:content
                 jcr:primaryType="nt:unstructured"
                 jcr:title="Sessions"
@@ -119,8 +118,7 @@
             </main>
         </jcr:content>
         <intro-to-sling
-                jcr:primaryType="kes:Page"
-                jcr:title="Introduction to Sling">
+                jcr:primaryType="kes:Page">
             <jcr:content
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Introduction to Sling"
@@ -165,8 +163,7 @@
             </jcr:content>
         </intro-to-sling>
         <advanced-htl
-                jcr:primaryType="kes:Page"
-                jcr:title="Advanced HTL Techniques">
+                jcr:primaryType="kes:Page">
             <jcr:content
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Advanced HTL Techniques"
@@ -211,8 +208,7 @@
             </jcr:content>
         </advanced-htl>
         <osgi-services
-                jcr:primaryType="kes:Page"
-                jcr:title="OSGi Services Deep Dive">
+                jcr:primaryType="kes:Page">
             <jcr:content
                     jcr:primaryType="nt:unstructured"
                     jcr:title="OSGi Services Deep Dive"
@@ -257,8 +253,7 @@
             </jcr:content>
         </osgi-services>
         <jcr-content-modeling
-                jcr:primaryType="kes:Page"
-                jcr:title="JCR Content Modeling">
+                jcr:primaryType="kes:Page">
             <jcr:content
                     jcr:primaryType="nt:unstructured"
                     jcr:title="JCR Content Modeling"
@@ -298,8 +293,7 @@
         </jcr-content-modeling>
     </sessions>
     <speakers
-            jcr:primaryType="kes:Page"
-            jcr:title="Speakers">
+            jcr:primaryType="kes:Page">
         <jcr:content
                 jcr:primaryType="nt:unstructured"
                 jcr:title="Speakers"
@@ -334,8 +328,7 @@
             </main>
         </jcr:content>
         <alice-smith
-                jcr:primaryType="kes:Page"
-                jcr:title="Alice Smith">
+                jcr:primaryType="kes:Page">
             <jcr:content
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Alice Smith"
@@ -375,8 +368,7 @@
             </jcr:content>
         </alice-smith>
         <bob-jones
-                jcr:primaryType="kes:Page"
-                jcr:title="Bob Jones">
+                jcr:primaryType="kes:Page">
             <jcr:content
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Bob Jones"
@@ -416,8 +408,7 @@
             </jcr:content>
         </bob-jones>
         <carol-white
-                jcr:primaryType="kes:Page"
-                jcr:title="Carol White">
+                jcr:primaryType="kes:Page">
             <jcr:content
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Carol White"
@@ -458,8 +449,7 @@
         </carol-white>
     </speakers>
     <sponsors
-            jcr:primaryType="kes:Page"
-            jcr:title="Sponsors">
+            jcr:primaryType="kes:Page">
         <jcr:content
                 jcr:primaryType="nt:unstructured"
                 jcr:title="Sponsors"
@@ -590,8 +580,7 @@
         </jcr:content>
     </sponsors>
     <schedule
-            jcr:primaryType="kes:Page"
-            jcr:title="Schedule">
+            jcr:primaryType="kes:Page">
         <jcr:content
                 jcr:primaryType="nt:unstructured"
                 jcr:title="Schedule"
@@ -645,8 +634,7 @@
         </jcr:content>
     </schedule>
     <venue
-            jcr:primaryType="kes:Page"
-            jcr:title="Venue">
+            jcr:primaryType="kes:Page">
         <jcr:content
                 jcr:primaryType="nt:unstructured"
                 jcr:title="Venue"

--- a/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
+++ b/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
@@ -81,7 +81,92 @@
                 </section>
             </container>
         </footer>
+        <dynamic-routes
+                jcr:primaryType="kes:DynamicRoutes">
+            <speaker-route
+                    jcr:primaryType="kes:DynamicRoute"
+                    pattern="speakers/{speaker}"
+                    targetPage="speaker-detail"
+                    parameters="[speaker-slug:speaker]"/>
+            <session-route
+                    jcr:primaryType="kes:DynamicRoute"
+                    pattern="sessions/{session}"
+                    targetPage="session-detail"
+                    parameters="[session-slug:session]"/>
+        </dynamic-routes>
     </jcr:content>
+    <speaker-detail
+            jcr:primaryType="kes:Page">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Speaker Detail"
+                jcr:description="Dynamic page template for individual speaker profiles"
+                sling:resourceType="kestros/commons/components/kestros-base-page"
+                hideInNavigation="true">
+            <main
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kestros/commons/components/content-area">
+                <section
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kestros/commons/components/structure/section"
+                        variations="[]">
+                    <container
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kestros/commons/components/structure/container"
+                            elementType="main"
+                            variations="[]">
+                        <heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h1"
+                                text="Speaker Detail"
+                                variations="[]"/>
+                        <text
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="kestros/commons/components/content/text"
+                                text="This page renders dynamically using the speaker-slug parameter from the URL."
+                                variations="[]"/>
+                    </container>
+                </section>
+            </main>
+        </jcr:content>
+    </speaker-detail>
+    <session-detail
+            jcr:primaryType="kes:Page">
+        <jcr:content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Session Detail"
+                jcr:description="Dynamic page template for individual session details"
+                sling:resourceType="kestros/commons/components/kestros-base-page"
+                hideInNavigation="true">
+            <main
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kestros/commons/components/content-area">
+                <section
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kestros/commons/components/structure/section"
+                        variations="[]">
+                    <container
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kestros/commons/components/structure/container"
+                            elementType="main"
+                            variations="[]">
+                        <heading
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h1"
+                                text="Session Detail"
+                                variations="[]"/>
+                        <text
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="kestros/commons/components/content/text"
+                                text="This page renders dynamically using the session-slug parameter from the URL."
+                                variations="[]"/>
+                    </container>
+                </section>
+            </main>
+        </jcr:content>
+    </session-detail>
     <sessions
             jcr:primaryType="kes:Page">
         <jcr:content

--- a/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
+++ b/signal-conf/src/content/jcr_root/content/sites/signal-conf/.content.xml
@@ -16,20 +16,19 @@
                 sling:resourceType="kestros/commons/components/inherited-content-area">
             <container
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="/libs/kestros/commons/components/structure/container"
+                    sling:resourceType="kestros/commons/components/structure/container"
                     elementType="header">
                 <section
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        sling:resourceType="kestros/commons/components/structure/section"
                         variations="[]">
                     <page-title
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/content/page-title"
-                            level="h1"
+                            sling:resourceType="kestros/commons/components/content/page-title"
                             variations="[]"/>
                     <navigation
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/navigation"
+                            sling:resourceType="kestros/commons/components/structure/navigation"
                             variations="[]"/>
                 </section>
             </container>
@@ -39,19 +38,19 @@
                 sling:resourceType="kestros/commons/components/content-area">
             <section
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="/libs/kestros/commons/components/structure/section"
+                    sling:resourceType="kestros/commons/components/structure/section"
                     variations="[]">
                 <container
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/structure/container"
+                        sling:resourceType="kestros/commons/components/structure/container"
                         elementType="main"
                         variations="[]">
                     <inherited-content-area
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/inherited-content-area">
+                            sling:resourceType="kestros/commons/components/inherited-content-area">
                         <breadcrumbs
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/breadcrumbs"
+                                sling:resourceType="kestros/commons/components/structure/breadcrumbs"
                                 variations="[]"/>
                     </inherited-content-area>
                 </container>
@@ -62,21 +61,21 @@
                 sling:resourceType="kestros/commons/components/inherited-content-area">
             <container
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="/libs/kestros/commons/components/structure/container"
+                    sling:resourceType="kestros/commons/components/structure/container"
                     elementType="footer">
                 <section
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        sling:resourceType="kestros/commons/components/structure/section"
                         variations="[]">
                     <heading
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/content/heading"
-                            level="h3"
-                            text="Signal Conf"
+                            sling:resourceType="kestros/commons/components/content/heading"
+                            headingType="h3"
+                            headingText="Signal Conf"
                             variations="[]"/>
                     <text
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/content/text"
+                            sling:resourceType="kestros/commons/components/content/text"
                             text="A Kestros CMS sample conference site built on UIkit."
                             variations="[]"/>
                 </section>
@@ -96,22 +95,22 @@
                     sling:resourceType="kestros/commons/components/content-area">
                 <section
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        sling:resourceType="kestros/commons/components/structure/section"
                         variations="[]">
                     <container
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            sling:resourceType="kestros/commons/components/structure/container"
                             elementType="main"
                             variations="[]">
                         <heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h2"
-                                text="Conference Sessions"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h2"
+                                headingText="Conference Sessions"
                                 variations="[]"/>
                         <card-list
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                sling:resourceType="kestros/commons/components/lists/card-list"
                                 kes:datasource="presenter-sessions"
                                 pagesPath="/content/sites/signal-conf/sessions"
                                 readMoreText="View Session"/>
@@ -136,27 +135,27 @@
                         sling:resourceType="kestros/commons/components/content-area">
                     <section
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            sling:resourceType="kestros/commons/components/structure/section"
                             variations="[]">
                         <container
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                sling:resourceType="kestros/commons/components/structure/container"
                                 elementType="main"
                                 variations="[]">
                             <heading
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                    level="h2"
-                                    text="Introduction to Sling"
+                                    sling:resourceType="kestros/commons/components/content/heading"
+                                    headingType="h2"
+                                    headingText="Introduction to Sling"
                                     variations="[]"/>
                             <text
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    sling:resourceType="kestros/commons/components/content/text"
                                     text="Learn the basics of Apache Sling in this introductory session."
                                     variations="[]"/>
                             <related-sessions
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                    sling:resourceType="kestros/commons/components/lists/card-list"
                                     kes:datasource="tag-search"
                                     pagesPath="/content/sites/signal-conf/sessions"
                                     readMoreText="View Session"/>
@@ -182,27 +181,27 @@
                         sling:resourceType="kestros/commons/components/content-area">
                     <section
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            sling:resourceType="kestros/commons/components/structure/section"
                             variations="[]">
                         <container
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                sling:resourceType="kestros/commons/components/structure/container"
                                 elementType="main"
                                 variations="[]">
                             <heading
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                    level="h2"
-                                    text="Advanced HTL Techniques"
+                                    sling:resourceType="kestros/commons/components/content/heading"
+                                    headingType="h2"
+                                    headingText="Advanced HTL Techniques"
                                     variations="[]"/>
                             <text
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    sling:resourceType="kestros/commons/components/content/text"
                                     text="A deep dive into advanced Sling HTL templating patterns and best practices."
                                     variations="[]"/>
                             <related-sessions
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                    sling:resourceType="kestros/commons/components/lists/card-list"
                                     kes:datasource="tag-search"
                                     pagesPath="/content/sites/signal-conf/sessions"
                                     readMoreText="View Session"/>
@@ -228,27 +227,27 @@
                         sling:resourceType="kestros/commons/components/content-area">
                     <section
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            sling:resourceType="kestros/commons/components/structure/section"
                             variations="[]">
                         <container
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                sling:resourceType="kestros/commons/components/structure/container"
                                 elementType="main"
                                 variations="[]">
                             <heading
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                    level="h2"
-                                    text="OSGi Services Deep Dive"
+                                    sling:resourceType="kestros/commons/components/content/heading"
+                                    headingType="h2"
+                                    headingText="OSGi Services Deep Dive"
                                     variations="[]"/>
                             <text
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    sling:resourceType="kestros/commons/components/content/text"
                                     text="Understanding OSGi service patterns and best practices in a Kestros/Sling context."
                                     variations="[]"/>
                             <related-sessions
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                    sling:resourceType="kestros/commons/components/lists/card-list"
                                     kes:datasource="tag-search"
                                     pagesPath="/content/sites/signal-conf/sessions"
                                     readMoreText="View Session"/>
@@ -274,22 +273,22 @@
                         sling:resourceType="kestros/commons/components/content-area">
                     <section
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            sling:resourceType="kestros/commons/components/structure/section"
                             variations="[]">
                         <container
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                sling:resourceType="kestros/commons/components/structure/container"
                                 elementType="main"
                                 variations="[]">
                             <heading
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                    level="h2"
-                                    text="JCR Content Modeling"
+                                    sling:resourceType="kestros/commons/components/content/heading"
+                                    headingType="h2"
+                                    headingText="JCR Content Modeling"
                                     variations="[]"/>
                             <text
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    sling:resourceType="kestros/commons/components/content/text"
                                     text="Best practices for structuring and modeling content in Apache Jackrabbit JCR repositories."
                                     variations="[]"/>
                         </container>
@@ -311,22 +310,22 @@
                     sling:resourceType="kestros/commons/components/content-area">
                 <section
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        sling:resourceType="kestros/commons/components/structure/section"
                         variations="[]">
                     <container
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            sling:resourceType="kestros/commons/components/structure/container"
                             elementType="main"
                             variations="[]">
                         <heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h2"
-                                text="Our Speakers"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h2"
+                                headingText="Our Speakers"
                                 variations="[]"/>
                         <card-list
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                                sling:resourceType="kestros/commons/components/lists/card-list"
                                 kes:datasource="presenters"
                                 pagesPath="/content/sites/signal-conf/speakers"
                                 readMoreText="View Sessions"/>
@@ -347,27 +346,27 @@
                         sling:resourceType="kestros/commons/components/content-area">
                     <section
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            sling:resourceType="kestros/commons/components/structure/section"
                             variations="[]">
                         <container
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                sling:resourceType="kestros/commons/components/structure/container"
                                 elementType="main"
                                 variations="[]">
                             <heading
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                    level="h2"
-                                    text="Alice Smith"
+                                    sling:resourceType="kestros/commons/components/content/heading"
+                                    headingType="h2"
+                                    headingText="Alice Smith"
                                     variations="[]"/>
                             <text
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    sling:resourceType="kestros/commons/components/content/text"
                                     text="Senior Developer specializing in Apache Sling and OSGi services."
                                     variations="[]"/>
                             <button-group
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                                    sling:resourceType="kestros/commons/components/content/button-group"
                                     kes:datasource="presenter-sessions"
                                     sessionsPath="/content/sites/signal-conf/sessions"/>
                         </container>
@@ -388,27 +387,27 @@
                         sling:resourceType="kestros/commons/components/content-area">
                     <section
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            sling:resourceType="kestros/commons/components/structure/section"
                             variations="[]">
                         <container
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                sling:resourceType="kestros/commons/components/structure/container"
                                 elementType="main"
                                 variations="[]">
                             <heading
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                    level="h2"
-                                    text="Bob Jones"
+                                    sling:resourceType="kestros/commons/components/content/heading"
+                                    headingType="h2"
+                                    headingText="Bob Jones"
                                     variations="[]"/>
                             <text
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    sling:resourceType="kestros/commons/components/content/text"
                                     text="Lead Architect with deep expertise in HTL templating and Kestros component design."
                                     variations="[]"/>
                             <button-group
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                                    sling:resourceType="kestros/commons/components/content/button-group"
                                     kes:datasource="presenter-sessions"
                                     sessionsPath="/content/sites/signal-conf/sessions"/>
                         </container>
@@ -429,27 +428,27 @@
                         sling:resourceType="kestros/commons/components/content-area">
                     <section
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/section"
+                            sling:resourceType="kestros/commons/components/structure/section"
                             variations="[]">
                         <container
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/container"
+                                sling:resourceType="kestros/commons/components/structure/container"
                                 elementType="main"
                                 variations="[]">
                             <heading
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                    level="h2"
-                                    text="Carol White"
+                                    sling:resourceType="kestros/commons/components/content/heading"
+                                    headingType="h2"
+                                    headingText="Carol White"
                                     variations="[]"/>
                             <text
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/text"
+                                    sling:resourceType="kestros/commons/components/content/text"
                                     text="JCR Content Modeling expert with years of experience designing Jackrabbit repository structures."
                                     variations="[]"/>
                             <button-group
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="/libs/kestros/commons/components/content/button-group"
+                                    sling:resourceType="kestros/commons/components/content/button-group"
                                     kes:datasource="presenter-sessions"
                                     sessionsPath="/content/sites/signal-conf/sessions"/>
                         </container>
@@ -471,51 +470,51 @@
                     sling:resourceType="kestros/commons/components/content-area">
                 <section
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        sling:resourceType="kestros/commons/components/structure/section"
                         variations="[]">
                     <container
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            sling:resourceType="kestros/commons/components/structure/container"
                             elementType="main"
                             variations="[]">
                         <heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h2"
-                                text="Our Sponsors"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h2"
+                                headingText="Our Sponsors"
                                 variations="[]"/>
                         <text
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/text"
+                                sling:resourceType="kestros/commons/components/content/text"
                                 text="Signal Conf is made possible by the generous support of our sponsors."
                                 variations="[]"/>
                         <platinum-heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h3"
-                                text="Platinum Sponsors"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h3"
+                                headingText="Platinum Sponsors"
                                 variations="[]"/>
                         <grid
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/grid"
+                                sling:resourceType="kestros/commons/components/structure/grid"
                                 variations="[]">
                             <column-1
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="Kestros IO"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="Kestros IO"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="Open-source CMS built on Apache Sling."
                                         variations="[]"/>
                                 <button
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/button"
+                                        sling:resourceType="kestros/commons/components/content/button"
                                         href="https://kestros.io"
                                         label="Visit Kestros"
                                         text="Visit Kestros"
@@ -526,18 +525,18 @@
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="Apache Software Foundation"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="Apache Software Foundation"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="The home of Apache Sling, Jackrabbit, and Felix."
                                         variations="[]"/>
                                 <button
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/button"
+                                        sling:resourceType="kestros/commons/components/content/button"
                                         href="https://apache.org"
                                         label="Visit ASF"
                                         text="Visit ASF"
@@ -546,26 +545,26 @@
                         </grid>
                         <gold-heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h3"
-                                text="Gold Sponsors"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h3"
+                                headingText="Gold Sponsors"
                                 variations="[]"/>
                         <grid-gold
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/grid"
+                                sling:resourceType="kestros/commons/components/structure/grid"
                                 variations="[]">
                             <column-1
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="UIkit"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="UIkit"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="A lightweight and modular front-end framework."
                                         variations="[]"/>
                             </column-1>
@@ -574,13 +573,13 @@
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="OSGi Alliance"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="OSGi Alliance"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="The specification body behind the OSGi framework."
                                         variations="[]"/>
                             </column-2>
@@ -603,40 +602,40 @@
                     sling:resourceType="kestros/commons/components/content-area">
                 <section
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        sling:resourceType="kestros/commons/components/structure/section"
                         variations="[]">
                     <container
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            sling:resourceType="kestros/commons/components/structure/container"
                             elementType="main"
                             variations="[]">
                         <heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h2"
-                                text="Conference Schedule"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h2"
+                                headingText="Conference Schedule"
                                 variations="[]"/>
                         <day-1-heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h3"
-                                text="Day 1"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h3"
+                                headingText="Day 1"
                                 variations="[]"/>
                         <day-1-table
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/table"
+                                sling:resourceType="kestros/commons/components/content/table"
                                 kes:datasource="schedule"
                                 sessionsPath="/content/sites/signal-conf/sessions"
                                 dayTag="/etc/tags/signal-conf/day-1"/>
                         <day-2-heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h3"
-                                text="Day 2"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h3"
+                                headingText="Day 2"
                                 variations="[]"/>
                         <day-2-table
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/table"
+                                sling:resourceType="kestros/commons/components/content/table"
                                 kes:datasource="schedule"
                                 sessionsPath="/content/sites/signal-conf/sessions"
                                 dayTag="/etc/tags/signal-conf/day-2"/>
@@ -658,57 +657,57 @@
                     sling:resourceType="kestros/commons/components/content-area">
                 <section
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="/libs/kestros/commons/components/structure/section"
+                        sling:resourceType="kestros/commons/components/structure/section"
                         variations="[]">
                     <container
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="/libs/kestros/commons/components/structure/container"
+                            sling:resourceType="kestros/commons/components/structure/container"
                             elementType="main"
                             variations="[]">
                         <heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h2"
-                                text="Conference Venue"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h2"
+                                headingText="Conference Venue"
                                 variations="[]"/>
                         <text
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/text"
+                                sling:resourceType="kestros/commons/components/content/text"
                                 text="Signal Conf takes place at the Kestros Convention Center, located in the heart of downtown."
                                 variations="[]"/>
                         <address-heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h3"
-                                text="Address"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h3"
+                                headingText="Address"
                                 variations="[]"/>
                         <address-text
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/text"
+                                sling:resourceType="kestros/commons/components/content/text"
                                 text="123 Sling Avenue, Suite 100, Apache City, CA 94105"
                                 variations="[]"/>
                         <getting-there-heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h3"
-                                text="Getting There"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h3"
+                                headingText="Getting There"
                                 variations="[]"/>
                         <grid
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/grid"
+                                sling:resourceType="kestros/commons/components/structure/grid"
                                 variations="[]">
                             <column-1
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="By Public Transit"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="By Public Transit"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="Take the Blue Line to Convention Center Station. Exit at Main Street and walk 2 blocks north."
                                         variations="[]"/>
                             </column-1>
@@ -717,13 +716,13 @@
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="By Car"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="By Car"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="Parking is available in the Kestros Convention Center garage at 125 Sling Avenue. Daily rate applies."
                                         variations="[]"/>
                             </column-2>
@@ -732,39 +731,39 @@
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="Nearby Hotels"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="Nearby Hotels"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="The Jackrabbit Inn (0.2 miles) and Sling Hotel (0.5 miles) offer conference rates. Use code SIGNALCONF at booking."
                                         variations="[]"/>
                             </column-3>
                         </grid>
                         <rooms-heading
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                level="h3"
-                                text="Meeting Rooms"
+                                sling:resourceType="kestros/commons/components/content/heading"
+                                headingType="h3"
+                                headingText="Meeting Rooms"
                                 variations="[]"/>
                         <grid-rooms
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="/libs/kestros/commons/components/structure/grid"
+                                sling:resourceType="kestros/commons/components/structure/grid"
                                 variations="[]">
                             <column-1
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="Main Hall"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="Main Hall"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="Capacity: 500. Keynotes and main track sessions."
                                         variations="[]"/>
                             </column-1>
@@ -773,13 +772,13 @@
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="Room A — Sling"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="Room A — Sling"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="Capacity: 120. Technical breakout sessions."
                                         variations="[]"/>
                             </column-2>
@@ -788,13 +787,13 @@
                                     sling:resourceType="kestros/commons/components/content-area">
                                 <heading
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/heading"
-                                        level="h4"
-                                        text="Room B — Felix"
+                                        sling:resourceType="kestros/commons/components/content/heading"
+                                        headingType="h4"
+                                        headingText="Room B — Felix"
                                         variations="[]"/>
                                 <text
                                         jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="/libs/kestros/commons/components/content/text"
+                                        sling:resourceType="kestros/commons/components/content/text"
                                         text="Capacity: 80. Workshops and hands-on labs."
                                         variations="[]"/>
                             </column-3>

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/ButtonGroupPresenterSessionsDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/ButtonGroupPresenterSessionsDataSource.java
@@ -1,0 +1,105 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.content.KestrosButton;
+import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.LinkUtils;
+import io.kestros.cms.components.basic.core.content.button.KestrosButtonImpl;
+import io.kestros.cms.sitebuilding.api.models.BaseComponent;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import io.kestros.cms.componenttypes.api.models.ComponentVariation;
+import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class ButtonGroupPresenterSessionsDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosButtonGroup {
+
+  private BaseContentPage containingPage;
+
+  BaseContentPage getContainingPage() {
+    if (containingPage == null) {
+      try {
+        BaseComponent component = getResource().adaptTo(BaseComponent.class);
+        if (component != null) {
+          containingPage = component.getContainingPage();
+        }
+      } catch (NoValidAncestorException e) {
+        return null;
+      }
+    }
+    return containingPage;
+  }
+
+  String getSessionsPath() {
+    return getResource().getValueMap().get("sessionsPath", String.class);
+  }
+
+  List<BaseContentPage> getPresenterSessions() {
+    List<BaseContentPage> sessions = new ArrayList<>();
+    String sessionsPath = getSessionsPath();
+    BaseContentPage presenterPage = getContainingPage();
+
+    if (sessionsPath == null || presenterPage == null) {
+      return sessions;
+    }
+
+    Resource sessionsResource = getResourceResolver().getResource(sessionsPath);
+    if (sessionsResource == null) {
+      return sessions;
+    }
+
+    BaseContentPage sessionsRoot = sessionsResource.adaptTo(BaseContentPage.class);
+    if (sessionsRoot == null) {
+      return sessions;
+    }
+
+    String presenterPath = presenterPage.getPath();
+
+    for (BaseContentPage sessionPage : sessionsRoot.getChildPages()) {
+      String sessionPresenter = sessionPage.getProperty("presenterPath", "");
+      if (presenterPath.equals(sessionPresenter)) {
+        sessions.add(sessionPage);
+      }
+    }
+
+    return sessions;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosButton> getButtonsElements() {
+    List<KestrosButton> buttons = new ArrayList<>();
+    int buttonIndex = 0;
+    for (BaseContentPage session : getPresenterSessions()) {
+      try {
+        buttons.add(
+            new KestrosButtonImpl(
+                session.getDisplayTitle(),
+                LinkUtils.getLink(session.getPath()),
+                null,
+                AnchorTarget.SAME_WINDOW,
+                null, null, null, null, false,
+                this,
+                "button",
+                "session-" + buttonIndex));
+        buttonIndex++;
+      } catch (Exception e) {
+        // Skip buttons that fail to construct — null-safe
+      }
+    }
+    return new ArrayList<>(buttons);
+  }
+
+  @Nonnull
+  @Override
+  public List<ComponentVariation> getButtonVariations() {
+    return getElementVariations("button", KestrosButton.RESOURCE_TYPE);
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/CardListPresentersDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/CardListPresentersDataSource.java
@@ -1,0 +1,63 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class CardListPresentersDataSource extends BaseContainerSlingModelDataSource implements
+                                                                                    KestrosCardList {
+
+  private BaseContentPage rootPage;
+
+  BaseContentPage getRootPage() {
+    if (rootPage == null) {
+      String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
+      if (pagesPath != null) {
+        Resource pageResource = getResourceResolver().getResource(pagesPath);
+        if (pageResource != null) {
+          rootPage = pageResource.adaptTo(BaseContentPage.class);
+        }
+      }
+    }
+    return rootPage;
+  }
+
+  @Nullable
+  public String getReadMoreText() {
+    return getResource().getValueMap().get("readMoreText", String.class);
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosCard> getCardElements() {
+    List<KestrosCard> cards = new ArrayList<>();
+    BaseContentPage root = getRootPage();
+    if (root == null) {
+      return cards;
+    }
+
+    for (BaseContentPage page : root.getChildPages()) {
+      try {
+        cards.add(
+            new KestrosCardImpl(page,
+                getReadMoreText(),
+                this,
+                "card",
+                page.getName()));
+      } catch (Exception e) {
+        // Skip cards that fail to construct — null-safe
+      }
+    }
+    return new ArrayList<>(cards);
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableCell.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableCell.java
@@ -1,0 +1,35 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SyntheticTableCell extends BaseContainerSyntheticResource implements KestrosTableCell {
+
+  private final String text;
+
+  public SyntheticTableCell(@Nonnull String text,
+      @Nonnull BaseSlingModelDataSource dataSource,
+      @Nonnull String resourcePrefix,
+      @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = text;
+  }
+
+  @Nullable
+  public String getText() {
+    return text;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getCellContentElements() {
+    return new ArrayList<>();
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableHeader.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableHeader.java
@@ -1,0 +1,27 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import io.kestros.cms.components.basic.core.BaseSyntheticResource;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SyntheticTableHeader extends BaseSyntheticResource implements KestrosTableHeader {
+
+  private final String text;
+
+  public SyntheticTableHeader(@Nonnull String text,
+      @Nonnull BaseSlingModelDataSource dataSource,
+      @Nonnull String resourcePrefix,
+      @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = text;
+  }
+
+  @Nullable
+  @Override
+  public String getText() {
+    return text;
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableRow.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableRow.java
@@ -1,0 +1,37 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SyntheticTableRow extends BaseContainerSyntheticResource implements KestrosTableRow {
+
+  private final List<KestrosTableCell> cells;
+
+  public SyntheticTableRow(@Nonnull List<KestrosTableCell> cells,
+      @Nonnull BaseSlingModelDataSource dataSource,
+      @Nonnull String resourcePrefix,
+      @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.cells = cells;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableCell> getCellElements() {
+    return new ArrayList<>(cells);
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(cells);
+  }
+}

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/TableScheduleDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/TableScheduleDataSource.java
@@ -1,0 +1,113 @@
+package io.kestros.samples.signalconf.datasources;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import io.kestros.cms.tagging.api.models.KestrosTag;
+import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class TableScheduleDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosTable {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private TagRetrievalService tagRetrievalService;
+
+  String getDayTag() {
+    return getResource().getValueMap().get("dayTag", String.class);
+  }
+
+  String getSessionsPath() {
+    return getResource().getValueMap().get("sessionsPath", String.class);
+  }
+
+  List<BaseContentPage> getSessionsForDay() {
+    List<BaseContentPage> sessions = new ArrayList<>();
+    String dayTag = getDayTag();
+    String sessionsPath = getSessionsPath();
+
+    if (dayTag == null || sessionsPath == null || tagRetrievalService == null) {
+      return sessions;
+    }
+
+    Resource sessionsResource = getResourceResolver().getResource(sessionsPath);
+    if (sessionsResource == null) {
+      return sessions;
+    }
+
+    BaseContentPage sessionsPage = sessionsResource.adaptTo(BaseContentPage.class);
+    if (sessionsPage == null) {
+      return sessions;
+    }
+
+    for (BaseContentPage sessionPage : sessionsPage.getChildPages()) {
+      List<KestrosTag> tags = tagRetrievalService.getTagsOnResource(sessionPage.getResource());
+      for (KestrosTag tag : tags) {
+        if (dayTag.equals(tag.getPath())) {
+          sessions.add(sessionPage);
+          break;
+        }
+      }
+    }
+    return sessions;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableHeader> getHeaderElements() {
+    List<KestrosTableHeader> headers = new ArrayList<>();
+    try {
+      headers.add(new SyntheticTableHeader("Time", this, "header", "time-header"));
+      headers.add(new SyntheticTableHeader("Session", this, "header", "session-header"));
+      headers.add(new SyntheticTableHeader("Presenter", this, "header", "presenter-header"));
+    } catch (Exception e) {
+      // Return empty headers on error — null-safe
+    }
+    return headers;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableRow> getRowElements() {
+    List<KestrosTableRow> rows = new ArrayList<>();
+    int rowIndex = 0;
+    for (BaseContentPage session : getSessionsForDay()) {
+      try {
+        String time = session.getProperty("sessionTime", "");
+        String title = session.getDisplayTitle();
+        String presenter = session.getProperty("presenterName", "");
+
+        List<KestrosTableCell> cells = Arrays.asList(
+            new SyntheticTableCell(time, this, "cell", "time-" + rowIndex),
+            new SyntheticTableCell(title, this, "cell", "session-" + rowIndex),
+            new SyntheticTableCell(presenter, this, "cell", "presenter-" + rowIndex)
+        );
+
+        rows.add(new SyntheticTableRow(cells, this, "row", "row-" + rowIndex));
+        rowIndex++;
+      } catch (Exception e) {
+        // Skip rows that fail to construct — null-safe
+      }
+    }
+    return rows;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(getRowElements());
+  }
+}

--- a/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/presenter-sessions.json
+++ b/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/presenter-sessions.json
@@ -1,0 +1,28 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Presenter Sessions",
+  "group": "Signal Conf",
+  "classPath": "io.kestros.samples.signalconf.datasources.ButtonGroupPresenterSessionsDataSource",
+  "container": true,
+  "edit": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/cms2/dialog",
+    "content": {
+      "jcr:primaryType": "nt:unstructured",
+      "sessions-path": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/pathfield",
+        "label": "Sessions Path",
+        "name": "sessionsPath",
+        "includePaths": [
+          "closest:kes:Site"
+        ],
+        "resourceTypes": [
+          "kes:Site",
+          "kes:Page"
+        ],
+        "autofocus": false
+      }
+    }
+  }
+}

--- a/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/presenters.json
+++ b/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/presenters.json
@@ -1,0 +1,35 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Presenters",
+  "group": "Signal Conf",
+  "classPath": "io.kestros.samples.signalconf.datasources.CardListPresentersDataSource",
+  "container": true,
+  "edit": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/cms2/dialog",
+    "content": {
+      "jcr:primaryType": "nt:unstructured",
+      "pages-path": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/pathfield",
+        "label": "Presenters Path",
+        "name": "pagesPath",
+        "includePaths": [
+          "closest:kes:Site"
+        ],
+        "resourceTypes": [
+          "kes:Site",
+          "kes:Page"
+        ],
+        "autofocus": false
+      },
+      "readMoreText": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Read More Text",
+        "name": "readMoreText",
+        "autofocus": false
+      }
+    }
+  }
+}

--- a/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/schedule.json
+++ b/signal-conf/src/main/resources/libs/kestros/samples/signal-conf/datasources/schedule.json
@@ -1,0 +1,41 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Schedule",
+  "group": "Signal Conf",
+  "classPath": "io.kestros.samples.signalconf.datasources.TableScheduleDataSource",
+  "container": true,
+  "edit": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/cms2/dialog",
+    "content": {
+      "jcr:primaryType": "nt:unstructured",
+      "sessions-path": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/pathfield",
+        "label": "Sessions Path",
+        "name": "sessionsPath",
+        "includePaths": [
+          "closest:kes:Site"
+        ],
+        "resourceTypes": [
+          "kes:Site",
+          "kes:Page"
+        ],
+        "autofocus": false
+      },
+      "day-tag": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/pathfield",
+        "label": "Day Tag",
+        "name": "dayTag",
+        "includePaths": [
+          "/etc/tags"
+        ],
+        "resourceTypes": [
+          "kes:Tag"
+        ],
+        "autofocus": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds dynamic route configuration to signal-conf sample site demonstrating the Dynamic Page API
- Two routes: `speakers/{speaker}` and `sessions/{session}` with parameter mappings
- Adds `speaker-detail` and `session-detail` target pages (hidden from nav)
- Includes all existing signal-conf sample site content from TASK-037
- Part of the Dynamic Pages feature (TASK-331 umbrella story)

## Integration Branch
This is the `feature/dynamic-pages` integration branch. Review together with the companion kestros-sitebuilding-api and kestros-sitebuilding-core PRs.

## Test plan
- [x] `mvn clean package` passes for signal-conf module
- [ ] Dynamic route resolution works when content is installed on CMS instance