### PR TITLE
feat: add datetime-local field to dialog-field-sample (TASK-029)

### DIFF
--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
@@ -14,6 +14,7 @@
     <dt>numberRequired</dt>     <dd>${properties.numberRequired @ context='text'}</dd>
     <dt>dateValue</dt>          <dd>${properties.dateValue @ context='text'}</dd>
     <dt>datetimeValue</dt>      <dd>${properties.datetimeValue @ context='text'}</dd>
+    <dt>datetimeLocalValue</dt> <dd>${properties.datetimeLocalValue @ context='text'}</dd>
     <dt>hiddenValue</dt>        <dd>${properties.hiddenValue @ context='text'}</dd>
     <dt>toggleValue</dt>        <dd>${properties.toggleValue @ context='text'}</dd>
     <dt>toggleDisabled</dt>     <dd>${properties.toggleDisabled @ context='text'}</dd>

--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
@@ -132,8 +132,15 @@
         <datetime-standard
             jcr:primaryType="nt:unstructured"
             sling:resourceType="kestros/cms2/fields/general/datetimefield"
-            label="Date + Time"
+            label="Date + Time (Composite)"
             name="datetimeValue"
+            required="{Boolean}false"/>
+
+        <datetime-local-standard
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/datetimelocalfield"
+            label="Date + Time (Single Input)"
+            name="datetimeLocalValue"
             required="{Boolean}false"/>
 
         <hidden-standard


### PR DESCRIPTION
## Summary
- Add datetime-local field to dialog-field-sample edit dialog
- Add datetimeLocalValue output to debugger component

## Test plan
- [ ] Field appears in dialog
- [ ] Value shows in debugger component after save