### PR TITLE
feat: add number field sample to dialog-field-sample component

### DIFF
--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/common/content.html
@@ -12,6 +12,7 @@
     <dt>pagePath</dt>           <dd>${properties.pagePath @ context='text'}</dd>
     <dt>numberValue</dt>        <dd>${properties.numberValue @ context='text'}</dd>
     <dt>numberRequired</dt>     <dd>${properties.numberRequired @ context='text'}</dd>
+    <dt>numberInteger</dt>      <dd>${properties.numberInteger @ context='text'}</dd>
     <dt>dateValue</dt>          <dd>${properties.dateValue @ context='text'}</dd>
     <dt>datetimeValue</dt>      <dd>${properties.datetimeValue @ context='text'}</dd>
     <dt>hiddenValue</dt>        <dd>${properties.hiddenValue @ context='text'}</dd>

--- a/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
+++ b/basic-components-sample/src/content/jcr_root/apps/kestros/samples/components/content/dialog-field-sample/edit/.content.xml
@@ -121,6 +121,14 @@
             label="Number (Required)"
             name="numberRequired"
             required="{Boolean}true"/>
+        <number-integer
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kestros/cms2/fields/general/numberfield"
+            label="Number (Integer Only)"
+            name="numberInteger"
+            integerOnly="{Boolean}true"
+            min="{Float}0"
+            max="{Float}100"/>
 
         <date-standard
             jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
TASK-028: Adds integer-only number field to the dialog-field-sample component.

Changes:
- Added `number-integer` field to edit dialog with `integerOnly=true`, `min=0`, `max=100`
- Added `numberInteger` output rendering in `common/content.html`

Cherry-picked from existing branch `feature/TASK-028-number-integer-field-sample` onto a clean develop base.