### PR TITLE
docs: add usage README for kestros-sample-sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # Kestros Sample Sites
+
+Sample site implementations demonstrating the Kestros CMS platform.
+
+## Purpose
+
+`kestros-sample-sites` provides reference site implementations that demonstrate how to build a site on the Kestros CMS. These samples serve as starting points for new site projects and as integration tests for the CMS foundation.
+
+**Current state:** This repository is a placeholder. For a working site implementation, see [`kestros-io-site`](https://github.com/kestros/kestros-io-site). For project scaffolding, see [`kestros-archetypes`](https://github.com/kestros/kestros-archetypes).
+
+## Installation & Build
+
+Not applicable -- this repository has no buildable artifacts.
+
+## Configuration
+
+Not applicable -- no active code.
+
+## API / Service Usage
+
+Not applicable. For site development guidance, see:
+
+- `kestros-sitebuilding-api` -- base classes for sites, pages, and components
+- `kestros-archetypes` -- Maven archetype for scaffolding a new site project
+- `kestros-io-site` -- working reference implementation
+
+## Dependencies
+
+Not applicable -- this is a placeholder repository.


### PR DESCRIPTION
## Summary
- Adds developer-facing usage documentation following the 6-section structure
- Documents purpose, installation, configuration, API/service usage, and dependencies

Part of TASK-188 — README.md usage docs for remaining repos batch 2.