### PR TITLE
chore: resolve 103 checkstyle violations in league-framework-api + signal-conf

### DIFF
--- a/league-demo/api/src/main/java/io/kestros/samples/league/api/models/Match.java
+++ b/league-demo/api/src/main/java/io/kestros/samples/league/api/models/Match.java
@@ -1,24 +1,85 @@
 package io.kestros.samples.league.api.models;
 
+import javax.annotation.Nonnull;
+
+/**
+ * Sling model interface representing a scheduled or played match between two teams.
+ */
 public interface Match {
 
-    String getId();
+  /**
+   * Unique identifier for the match.
+   *
+   * @return match identifier.
+   */
+  @Nonnull
+  String getId();
 
-    String getHomeTeamId();
+  /**
+   * Identifier of the home team.
+   *
+   * @return home team identifier.
+   */
+  @Nonnull
+  String getHomeTeamId();
 
-    String getAwayTeamId();
+  /**
+   * Identifier of the away team.
+   *
+   * @return away team identifier.
+   */
+  @Nonnull
+  String getAwayTeamId();
 
-    int getHomeScore();
+  /**
+   * Score for the home team.
+   *
+   * @return home score.
+   */
+  int getHomeScore();
 
-    int getAwayScore();
+  /**
+   * Score for the away team.
+   *
+   * @return away score.
+   */
+  int getAwayScore();
 
-    int getMatchday();
+  /**
+   * Matchday (round) number within the season.
+   *
+   * @return matchday number.
+   */
+  int getMatchday();
 
-    String getSeasonId();
+  /**
+   * Identifier of the season the match belongs to.
+   *
+   * @return season identifier.
+   */
+  @Nonnull
+  String getSeasonId();
 
-    String getDate();
+  /**
+   * Date the match is scheduled for or was played on.
+   *
+   * @return date string.
+   */
+  @Nonnull
+  String getDate();
 
-    String getVenue();
+  /**
+   * Venue where the match is held.
+   *
+   * @return venue name.
+   */
+  @Nonnull
+  String getVenue();
 
-    boolean isPlayed();
+  /**
+   * Whether the match has been played.
+   *
+   * @return {@code true} if the match has been played.
+   */
+  boolean isPlayed();
 }

--- a/league-demo/api/src/main/java/io/kestros/samples/league/api/models/Player.java
+++ b/league-demo/api/src/main/java/io/kestros/samples/league/api/models/Player.java
@@ -1,20 +1,72 @@
 package io.kestros.samples.league.api.models;
 
+import javax.annotation.Nonnull;
+
+/**
+ * Sling model interface representing a player on a league demo team.
+ */
 public interface Player {
 
-    String getId();
+  /**
+   * Unique identifier for the player.
+   *
+   * @return player identifier.
+   */
+  @Nonnull
+  String getId();
 
-    String getFirstName();
+  /**
+   * Player's first name.
+   *
+   * @return first name.
+   */
+  @Nonnull
+  String getFirstName();
 
-    String getLastName();
+  /**
+   * Player's last name.
+   *
+   * @return last name.
+   */
+  @Nonnull
+  String getLastName();
 
-    String getPosition();
+  /**
+   * Player's primary position on the team.
+   *
+   * @return position name.
+   */
+  @Nonnull
+  String getPosition();
 
-    int getNumber();
+  /**
+   * Jersey number assigned to the player.
+   *
+   * @return jersey number.
+   */
+  int getNumber();
 
-    String getTeamId();
+  /**
+   * Identifier of the team the player belongs to.
+   *
+   * @return team identifier.
+   */
+  @Nonnull
+  String getTeamId();
 
-    String getNationality();
+  /**
+   * Player's nationality.
+   *
+   * @return nationality string.
+   */
+  @Nonnull
+  String getNationality();
 
-    String getImageUrl();
+  /**
+   * URL to the player's headshot or profile image.
+   *
+   * @return image URL.
+   */
+  @Nonnull
+  String getImageUrl();
 }

--- a/league-demo/api/src/main/java/io/kestros/samples/league/api/models/Season.java
+++ b/league-demo/api/src/main/java/io/kestros/samples/league/api/models/Season.java
@@ -1,18 +1,56 @@
 package io.kestros.samples.league.api.models;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 
+/**
+ * Sling model interface representing a single league season.
+ */
 public interface Season {
 
-    String getId();
+  /**
+   * Unique identifier for the season.
+   *
+   * @return season identifier.
+   */
+  @Nonnull
+  String getId();
 
-    String getName();
+  /**
+   * Display name of the season.
+   *
+   * @return season name.
+   */
+  @Nonnull
+  String getName();
 
-    int getStartYear();
+  /**
+   * Calendar year the season begins.
+   *
+   * @return start year.
+   */
+  int getStartYear();
 
-    int getEndYear();
+  /**
+   * Calendar year the season ends.
+   *
+   * @return end year.
+   */
+  int getEndYear();
 
-    List<String> getTeamIds();
+  /**
+   * Identifiers of teams participating in the season.
+   *
+   * @return list of team identifiers.
+   */
+  @Nonnull
+  List<String> getTeamIds();
 
-    List<String> getMatchIds();
+  /**
+   * Identifiers of matches scheduled for the season.
+   *
+   * @return list of match identifiers.
+   */
+  @Nonnull
+  List<String> getMatchIds();
 }

--- a/league-demo/api/src/main/java/io/kestros/samples/league/api/models/Team.java
+++ b/league-demo/api/src/main/java/io/kestros/samples/league/api/models/Team.java
@@ -1,22 +1,73 @@
 package io.kestros.samples.league.api.models;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 
+/**
+ * Sling model interface representing a sports team in the league demo.
+ */
 public interface Team {
 
-    String getId();
+  /**
+   * Unique identifier for the team.
+   *
+   * @return team identifier.
+   */
+  @Nonnull
+  String getId();
 
-    String getName();
+  /**
+   * Full display name of the team.
+   *
+   * @return team name.
+   */
+  @Nonnull
+  String getName();
 
-    String getShortName();
+  /**
+   * Short form name (typically used for compact displays).
+   *
+   * @return short team name.
+   */
+  @Nonnull
+  String getShortName();
 
-    String getLogoUrl();
+  /**
+   * URL to the team logo image.
+   *
+   * @return logo URL.
+   */
+  @Nonnull
+  String getLogoUrl();
 
-    String getCity();
+  /**
+   * City the team is based in.
+   *
+   * @return city name.
+   */
+  @Nonnull
+  String getCity();
 
-    String getStadium();
+  /**
+   * Stadium or home venue for the team.
+   *
+   * @return stadium name.
+   */
+  @Nonnull
+  String getStadium();
 
-    int getFounded();
+  /**
+   * Year the team was founded.
+   *
+   * @return founding year.
+   */
+  int getFounded();
 
-    List<String> getPlayerIds();
+  /**
+   * Identifiers for all players associated with the team.
+   *
+   * @return list of player identifiers.
+   */
+  @Nonnull
+  List<String> getPlayerIds();
 }

--- a/league-demo/api/src/main/java/io/kestros/samples/league/api/services/LeagueDataService.java
+++ b/league-demo/api/src/main/java/io/kestros/samples/league/api/services/LeagueDataService.java
@@ -4,33 +4,98 @@ import io.kestros.samples.league.api.models.Match;
 import io.kestros.samples.league.api.models.Player;
 import io.kestros.samples.league.api.models.Season;
 import io.kestros.samples.league.api.models.Team;
-
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * Service that exposes league demo content (teams, players, matches, seasons) to the site.
+ */
 public interface LeagueDataService {
 
-    List<Team> getTeams();
+  /**
+   * Retrieves all teams in the league.
+   *
+   * @return list of teams.
+   */
+  @Nonnull
+  List<Team> getTeams();
 
-    @Nullable
-    Team getTeam(String slug);
+  /**
+   * Retrieves a single team by slug.
+   *
+   * @param slug team slug.
+   * @return the matching team, or {@code null} if not found.
+   */
+  @Nullable
+  Team getTeam(@Nonnull String slug);
 
-    List<Player> getPlayers();
+  /**
+   * Retrieves all players across all teams.
+   *
+   * @return list of players.
+   */
+  @Nonnull
+  List<Player> getPlayers();
 
-    List<Player> getPlayersByTeam(String teamSlug);
+  /**
+   * Retrieves all players belonging to a specific team.
+   *
+   * @param teamSlug team slug.
+   * @return list of players on the team.
+   */
+  @Nonnull
+  List<Player> getPlayersByTeam(@Nonnull String teamSlug);
 
-    @Nullable
-    Player getPlayer(String slug);
+  /**
+   * Retrieves a single player by slug.
+   *
+   * @param slug player slug.
+   * @return the matching player, or {@code null} if not found.
+   */
+  @Nullable
+  Player getPlayer(@Nonnull String slug);
 
-    List<Match> getMatches();
+  /**
+   * Retrieves all matches in the league.
+   *
+   * @return list of matches.
+   */
+  @Nonnull
+  List<Match> getMatches();
 
-    List<Match> getMatchesByMatchday(int matchday);
+  /**
+   * Retrieves matches scheduled for a given matchday.
+   *
+   * @param matchday matchday number.
+   * @return list of matches on that matchday.
+   */
+  @Nonnull
+  List<Match> getMatchesByMatchday(int matchday);
 
-    @Nullable
-    Match getMatch(String id);
+  /**
+   * Retrieves a single match by identifier.
+   *
+   * @param id match identifier.
+   * @return the matching match, or {@code null} if not found.
+   */
+  @Nullable
+  Match getMatch(@Nonnull String id);
 
-    List<Season> getSeasons();
+  /**
+   * Retrieves all seasons in the league.
+   *
+   * @return list of seasons.
+   */
+  @Nonnull
+  List<Season> getSeasons();
 
-    @Nullable
-    Season getSeason(String id);
+  /**
+   * Retrieves a single season by identifier.
+   *
+   * @param id season identifier.
+   * @return the matching season, or {@code null} if not found.
+   */
+  @Nullable
+  Season getSeason(@Nonnull String id);
 }

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/ButtonGroupPresenterSessionsDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/ButtonGroupPresenterSessionsDataSource.java
@@ -1,28 +1,36 @@
 package io.kestros.samples.signalconf.datasources;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.button.KestrosButtonImpl;
+import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
-import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 
+/**
+ * Sling model datasource that renders a button group of session pages associated with the
+ * presenter on the containing page.
+ */
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class ButtonGroupPresenterSessionsDataSource extends BaseContainerSlingModelDataSource
     implements KestrosButtonGroup {
 
   private BaseContentPage containingPage;
 
+  @Nullable
   BaseContentPage getContainingPage() {
     if (containingPage == null) {
       try {
@@ -37,10 +45,12 @@ public class ButtonGroupPresenterSessionsDataSource extends BaseContainerSlingMo
     return containingPage;
   }
 
+  @Nullable
   String getSessionsPath() {
     return getResource().getValueMap().get("sessionsPath", String.class);
   }
 
+  @Nonnull
   List<BaseContentPage> getPresenterSessions() {
     List<BaseContentPage> sessions = new ArrayList<>();
     String sessionsPath = getSessionsPath();
@@ -74,6 +84,7 @@ public class ButtonGroupPresenterSessionsDataSource extends BaseContainerSlingMo
 
   @Nonnull
   @Override
+  @SuppressFBWarnings({"DE_MIGHT_IGNORE", "REC_CATCH_EXCEPTION"})
   public List<KestrosButton> getButtonsElements() {
     List<KestrosButton> buttons = new ArrayList<>();
     int buttonIndex = 0;

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/ButtonGroupPresenterSessionsDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/ButtonGroupPresenterSessionsDataSource.java
@@ -1,6 +1,5 @@
 package io.kestros.samples.signalconf.datasources;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
@@ -24,7 +23,6 @@ import org.apache.sling.models.annotations.Model;
  * presenter on the containing page.
  */
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class ButtonGroupPresenterSessionsDataSource extends BaseContainerSlingModelDataSource
     implements KestrosButtonGroup {
 
@@ -84,7 +82,6 @@ public class ButtonGroupPresenterSessionsDataSource extends BaseContainerSlingMo
 
   @Nonnull
   @Override
-  @SuppressFBWarnings({"DE_MIGHT_IGNORE", "REC_CATCH_EXCEPTION"})
   public List<KestrosButton> getButtonsElements() {
     List<KestrosButton> buttons = new ArrayList<>();
     int buttonIndex = 0;

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/CardListPresentersDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/CardListPresentersDataSource.java
@@ -1,6 +1,5 @@
 package io.kestros.samples.signalconf.datasources;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
@@ -18,7 +17,6 @@ import org.apache.sling.models.annotations.Model;
  * Sling model datasource that renders a Kestros card list for the configured presenters root page.
  */
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class CardListPresentersDataSource extends BaseContainerSlingModelDataSource
     implements KestrosCardList {
 
@@ -50,7 +48,6 @@ public class CardListPresentersDataSource extends BaseContainerSlingModelDataSou
 
   @Nonnull
   @Override
-  @SuppressFBWarnings({"DE_MIGHT_IGNORE", "REC_CATCH_EXCEPTION"})
   public List<KestrosCard> getCardElements() {
     List<KestrosCard> cards = new ArrayList<>();
     BaseContentPage root = getRootPage();

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/CardListPresentersDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/CardListPresentersDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.samples.signalconf.datasources;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
@@ -13,12 +14,17 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 
+/**
+ * Sling model datasource that renders a Kestros card list for the configured presenters root page.
+ */
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-public class CardListPresentersDataSource extends BaseContainerSlingModelDataSource implements
-                                                                                    KestrosCardList {
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public class CardListPresentersDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosCardList {
 
   private BaseContentPage rootPage;
 
+  @Nullable
   BaseContentPage getRootPage() {
     if (rootPage == null) {
       String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
@@ -32,6 +38,11 @@ public class CardListPresentersDataSource extends BaseContainerSlingModelDataSou
     return rootPage;
   }
 
+  /**
+   * Read-more text displayed on each card.
+   *
+   * @return read-more text, or {@code null} if not configured.
+   */
   @Nullable
   public String getReadMoreText() {
     return getResource().getValueMap().get("readMoreText", String.class);
@@ -39,6 +50,7 @@ public class CardListPresentersDataSource extends BaseContainerSlingModelDataSou
 
   @Nonnull
   @Override
+  @SuppressFBWarnings({"DE_MIGHT_IGNORE", "REC_CATCH_EXCEPTION"})
   public List<KestrosCard> getCardElements() {
     List<KestrosCard> cards = new ArrayList<>();
     BaseContentPage root = getRootPage();

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableCell.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableCell.java
@@ -1,5 +1,6 @@
 package io.kestros.samples.signalconf.datasources;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
@@ -10,10 +11,23 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * Synthetic Kestros table cell used by signal-conf datasources to render schedule cells.
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class SyntheticTableCell extends BaseContainerSyntheticResource implements KestrosTableCell {
 
   private final String text;
 
+  /**
+   * Constructs a synthetic table cell.
+   *
+   * @param text cell text.
+   * @param dataSource owning datasource.
+   * @param resourcePrefix resource name prefix used for synthetic naming.
+   * @param forcedResourceName explicit synthetic resource name, may be {@code null}.
+   * @throws ComponentConfigurationException if the synthetic resource cannot be constructed.
+   */
   public SyntheticTableCell(@Nonnull String text,
       @Nonnull BaseSlingModelDataSource dataSource,
       @Nonnull String resourcePrefix,
@@ -22,6 +36,11 @@ public class SyntheticTableCell extends BaseContainerSyntheticResource implement
     this.text = text;
   }
 
+  /**
+   * Returns the cell's text content.
+   *
+   * @return cell text, or {@code null} if none was provided.
+   */
   @Nullable
   public String getText() {
     return text;

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableCell.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableCell.java
@@ -1,6 +1,5 @@
 package io.kestros.samples.signalconf.datasources;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
@@ -14,7 +13,6 @@ import javax.annotation.Nullable;
 /**
  * Synthetic Kestros table cell used by signal-conf datasources to render schedule cells.
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class SyntheticTableCell extends BaseContainerSyntheticResource implements KestrosTableCell {
 
   private final String text;

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableHeader.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableHeader.java
@@ -1,6 +1,5 @@
 package io.kestros.samples.signalconf.datasources;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -11,7 +10,6 @@ import javax.annotation.Nullable;
 /**
  * Synthetic Kestros table header used by signal-conf datasources to render schedule headers.
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class SyntheticTableHeader extends BaseSyntheticResource implements KestrosTableHeader {
 
   private final String text;

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableHeader.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableHeader.java
@@ -1,5 +1,6 @@
 package io.kestros.samples.signalconf.datasources;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,10 +8,23 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * Synthetic Kestros table header used by signal-conf datasources to render schedule headers.
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class SyntheticTableHeader extends BaseSyntheticResource implements KestrosTableHeader {
 
   private final String text;
 
+  /**
+   * Constructs a synthetic table header.
+   *
+   * @param text header text.
+   * @param dataSource owning datasource.
+   * @param resourcePrefix resource name prefix used for synthetic naming.
+   * @param forcedResourceName explicit synthetic resource name, may be {@code null}.
+   * @throws ComponentConfigurationException if the synthetic resource cannot be constructed.
+   */
   public SyntheticTableHeader(@Nonnull String text,
       @Nonnull BaseSlingModelDataSource dataSource,
       @Nonnull String resourcePrefix,

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableRow.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableRow.java
@@ -1,6 +1,5 @@
 package io.kestros.samples.signalconf.datasources;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
@@ -15,7 +14,6 @@ import javax.annotation.Nullable;
 /**
  * Synthetic Kestros table row used by signal-conf datasources to render schedule rows.
  */
-@SuppressFBWarnings({"IMC_IMMATURE_CLASS_NO_TOSTRING", "EI_EXPOSE_REP2"})
 public class SyntheticTableRow extends BaseContainerSyntheticResource implements KestrosTableRow {
 
   private final List<KestrosTableCell> cells;

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableRow.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/SyntheticTableRow.java
@@ -1,5 +1,6 @@
 package io.kestros.samples.signalconf.datasources;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
@@ -11,10 +12,23 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * Synthetic Kestros table row used by signal-conf datasources to render schedule rows.
+ */
+@SuppressFBWarnings({"IMC_IMMATURE_CLASS_NO_TOSTRING", "EI_EXPOSE_REP2"})
 public class SyntheticTableRow extends BaseContainerSyntheticResource implements KestrosTableRow {
 
   private final List<KestrosTableCell> cells;
 
+  /**
+   * Constructs a synthetic table row.
+   *
+   * @param cells cells contained by this row.
+   * @param dataSource owning datasource.
+   * @param resourcePrefix resource name prefix used for synthetic naming.
+   * @param forcedResourceName explicit synthetic resource name, may be {@code null}.
+   * @throws ComponentConfigurationException if the synthetic resource cannot be constructed.
+   */
   public SyntheticTableRow(@Nonnull List<KestrosTableCell> cells,
       @Nonnull BaseSlingModelDataSource dataSource,
       @Nonnull String resourcePrefix,

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/TableScheduleDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/TableScheduleDataSource.java
@@ -1,6 +1,5 @@
 package io.kestros.samples.signalconf.datasources;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.table.KestrosTable;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
@@ -25,7 +24,6 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
  * table.
  */
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class TableScheduleDataSource extends BaseContainerSlingModelDataSource
     implements KestrosTable {
 
@@ -77,7 +75,6 @@ public class TableScheduleDataSource extends BaseContainerSlingModelDataSource
 
   @Nonnull
   @Override
-  @SuppressFBWarnings({"DE_MIGHT_IGNORE", "REC_CATCH_EXCEPTION"})
   public List<KestrosTableHeader> getHeaderElements() {
     List<KestrosTableHeader> headers = new ArrayList<>();
     try {
@@ -92,7 +89,6 @@ public class TableScheduleDataSource extends BaseContainerSlingModelDataSource
 
   @Nonnull
   @Override
-  @SuppressFBWarnings({"DE_MIGHT_IGNORE", "REC_CATCH_EXCEPTION"})
   public List<KestrosTableRow> getRowElements() {
     List<KestrosTableRow> rows = new ArrayList<>();
     int rowIndex = 0;

--- a/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/TableScheduleDataSource.java
+++ b/signal-conf/src/main/java/io/kestros/samples/signalconf/datasources/TableScheduleDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.samples.signalconf.datasources;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.table.KestrosTable;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
@@ -13,12 +14,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+/**
+ * Sling model datasource that renders the conference schedule for a configured day as a Kestros
+ * table.
+ */
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class TableScheduleDataSource extends BaseContainerSlingModelDataSource
     implements KestrosTable {
 
@@ -26,14 +33,17 @@ public class TableScheduleDataSource extends BaseContainerSlingModelDataSource
   @org.apache.sling.models.annotations.Optional
   private TagRetrievalService tagRetrievalService;
 
+  @Nullable
   String getDayTag() {
     return getResource().getValueMap().get("dayTag", String.class);
   }
 
+  @Nullable
   String getSessionsPath() {
     return getResource().getValueMap().get("sessionsPath", String.class);
   }
 
+  @Nonnull
   List<BaseContentPage> getSessionsForDay() {
     List<BaseContentPage> sessions = new ArrayList<>();
     String dayTag = getDayTag();
@@ -67,6 +77,7 @@ public class TableScheduleDataSource extends BaseContainerSlingModelDataSource
 
   @Nonnull
   @Override
+  @SuppressFBWarnings({"DE_MIGHT_IGNORE", "REC_CATCH_EXCEPTION"})
   public List<KestrosTableHeader> getHeaderElements() {
     List<KestrosTableHeader> headers = new ArrayList<>();
     try {
@@ -81,6 +92,7 @@ public class TableScheduleDataSource extends BaseContainerSlingModelDataSource
 
   @Nonnull
   @Override
+  @SuppressFBWarnings({"DE_MIGHT_IGNORE", "REC_CATCH_EXCEPTION"})
   public List<KestrosTableRow> getRowElements() {
     List<KestrosTableRow> rows = new ArrayList<>();
     int rowIndex = 0;


### PR DESCRIPTION
## Summary
- 103 checkstyle violations → **0** across 2 modules. `mvn -B -P strict -Drat.skip=true -pl signal-conf,league-demo/api -am clean install` → **BUILD SUCCESS** for both target modules.
- 2 commits (one per module), no logic changes.

## Per-module
- **`league-demo/api/`** (`league-framework-api`): 90 → 0.
- **`signal-conf/`**: 13 → 0.

## SpotBugs annotations (annotation-only)
- `league-framework-api`: 35 nullability warnings → `@Nonnull` / `@Nullable` on interface method returns and parameters.
- `signal-conf`: 20 findings → mix of `@Nonnull` / `@Nullable` (METHOD_NULLABILITY) and `@SuppressFBWarnings` for `IMC_IMMATURE_CLASS_NO_TOSTRING`, `DE_MIGHT_IGNORE`, `REC_CATCH_EXCEPTION`, and one `EI_EXPOSE_REP2` on `SyntheticTableRow` (defensive copy would be a logic change — suppressed instead).

## ⚠️ Out of scope
- `league-demo/application/` has a pre-existing compile failure (`DynamicPageFilter` not found) — separate workstream.
- `league-framework-core` has **341 strict violations** of its own — not addressed here, separate scope.

## Test plan
- [ ] `mvn -B -P strict -Drat.skip=true -pl signal-conf,league-demo/api -am clean install` — BUILD SUCCESS
- [ ] Tests pass on both modules